### PR TITLE
Enhance Repeat Attack: Button to remove all attacks

### DIFF
--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -100,6 +100,10 @@ class Repeater {
     this.attacks.splice(position, 1);
     this.saveAttacks();
   }
+  removeAllAttacks() {
+    this.attacks = [];
+    this.saveAttacks();
+  }
   stopFiring(planetId) {
     this.attacks = this.attacks.filter(item => item.srcId !== planetId);
     this.saveAttacks();
@@ -245,7 +249,7 @@ function AddAttack({ onCreate, stopFiring, stopBeingFiredAt }) {
         style=${{fontSize: '90%'}}
       >
         <button
-          style=${{...VerticalSpacing, width: 80, marginRight: 5}}
+          style=${{...VerticalSpacing, width: 80, marginRight: 10}}
           onClick=${() => planet && stopFiring(planet.locationId)}
         >
           Stop Firing
@@ -307,8 +311,11 @@ function AttackList({ repeater }) {
     />
     <h1 style=${{...HalfVerticalSpacing, fontWeight: 'bold'}}>
       Active (${actionsChildren.length})
+      <button style=${{ float: 'right', marginLeft: 10 }} onClick=${() => {repeater.removeAllAttacks(); setAttacks([])}}>
+        Clear All
+      </button>
       <button style=${{ float: 'right' }} onClick=${() => setAttacks([...repeater.attacks])}>
-        refresh
+        Refresh
       </button>
     </h1>
     <div style=${actionList}>${actionsChildren.length ? actionsChildren : 'No Actions.'}</div>


### PR DESCRIPTION
Added a new button to the embedded Repeat Attack plugin on Arena Client. Here is the plugin before and after the "Clear All" button is pressed. I've tested, the planets stop firing too.

<img width="285" alt="Screenshot 2022-06-20 at 20 02 15" src="https://user-images.githubusercontent.com/11883046/174608024-b055df98-b0e7-4acb-8ce1-c3f40b2b9453.png">

<img width="286" alt="Screenshot 2022-06-20 at 20 02 56" src="https://user-images.githubusercontent.com/11883046/174608038-473774ae-3466-4503-92d5-04d159b1fd7d.png">
