### PR TITLE
Enhance Repeat Attack (after Round 4)

### DIFF
--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -247,6 +247,9 @@ function AddAttack({ startFiring, stopFiring, stopBeingFiredAt }) {
           >${target ? getPlanetString(target.locationId) : '?????'}</span
         >
       </div>
+      <div style=${{marginBottom: 5}}>
+        Send Silver? <input type='checkbox' checked=${sendSilver} onChange=${() => setSendSilver(!sendSilver)}/>
+      </div>
       <div>
         <button
           style=${{...VerticalSpacing, width: 150}}
@@ -254,7 +257,7 @@ function AddAttack({ startFiring, stopFiring, stopBeingFiredAt }) {
             srcId: source.locationId,
             targetId: target.locationId,
             pcTrigger,
-            pcRemain,
+            pcRemain: ((pcTrigger <= pcRemain) ? parseInt(pcTrigger / 2) : pcRemain),
             sendSilver
           })}
         >

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -51,6 +51,7 @@ const sendSilverStatusesIcon = ['-', 'U', '$'];
 const UPGRADE_FIRST = 1;
 const SEND_ALL_SILVER = 2;
 const INITIAL_SILVER_STATUS = UPGRADE_FIRST;
+const toggleSilverStatus = val => (val + 1) % 3;  // 3 way toggle
 
 const getPlanetString = (locationId) => {
   const planet = df.getPlanetWithId(locationId);
@@ -125,6 +126,10 @@ class Repeater {
     this.attacks = newAttacks;
     this.saveAttacks();
   }
+  toggleSilver(position) {
+    this.attacks[position].sendSilverStatus = toggleSilverStatus(this.attacks[position].sendSilverStatus);
+    this.saveAttacks();
+  }
   removeAttack(position) {
     this.attacks.splice(position, 1);
     this.saveAttacks();
@@ -192,7 +197,7 @@ function centerPlanet(id) {
 function planetShort(locationId) {
   return locationId.substring(4, 9);
 }
-function Attack({ attack, onDelete }) {
+function Attack({ attack, onToggleSilver, onDelete }) {
   const srcString = getPlanetString(attack.srcId);
   const targetString = getPlanetString(attack.targetId);
   const finalSrc = srcString.length > MAX_CHARS ? srcString.slice(0, MAX_CHARS - 3).concat('...') : srcString;
@@ -208,8 +213,10 @@ function Attack({ attack, onDelete }) {
           >${finalTarget}</span
         ></span
       >
-      ${`${attack.pcTrigger}% -> ${attack.pcRemain}% ${sendSilverStatusesIcon[attack.sendSilverStatus]}`}
-      <button style=${{backgroundColor: 'black'}} onClick=${onDelete}>X</button>
+      ${`${attack.pcTrigger}% -> ${attack.pcRemain}% `}
+      <button onClick=${onToggleSilver}>${`${sendSilverStatusesIcon[attack.sendSilverStatus]}`}</button>
+      ${` `}
+      <button onClick=${onDelete}>X</button>
     </div>
   `;
 }
@@ -268,7 +275,7 @@ function AddAttack({ startFiring, stopFiring, stopBeingFiredAt }) {
       <div style=${{marginBottom: 10}}>
         Choose when to send silver: <button
           style=${{width: 150, height: 23, fontSize: '90%'}}
-          onClick=${() => setSendSilverStatus((sendSilverStatus + 1) % 3)}
+          onClick=${() => setSendSilverStatus(toggleSilverStatus(sendSilverStatus))}
         >
           ${sendSilverStatuses[sendSilverStatus]}
         </button>
@@ -339,9 +346,8 @@ function AttackList({ repeater }) {
     return html`
       <${Attack}
         attack=${action}
-        onDelete=${() => {
-          repeater.removeAttack(index);
-        }}
+        onToggleSilver=${() => repeater.toggleSilver(index)}
+        onDelete=${() => repeater.removeAttack(index)}
       />
     `;
   });

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -62,9 +62,10 @@ const SEND_ALL_SILVER = 2;
 const INITIAL_SILVER_STATUS = UPGRADE_FIRST;
 const toggleSilverStatus = val => (val + 1) % 3;  // 3 way toggle
 
+const PLANET_UNKNOWN = '?????';
 const getPlanetString = (locationId) => {
   const planet = df.getPlanetWithId(locationId);
-  if(!planet) return '?????'
+  if(!planet) return PLANET_UNKNOWN;
   let type = 'P';
   if( planet.planetType == PlanetType.SILVER_MINE) type = 'A'
   else if (planet.planetType == PlanetType.RUINS) type = 'F'
@@ -185,14 +186,18 @@ const ExecuteAttack = ({srcId, targetId, active, pcTrigger, pcRemain, sendSilver
     df.move(srcId, targetId, FORCES, silver);
   }
 };
-let Spacing = {
+let Margin_3L_3R = {
+  marginLeft: '3px',
+  marginRight: '3px',
+};
+let Margin_12L_12R = {
   marginLeft: '12px',
   marginRight: '12px',
 };
-let VerticalSpacing = {
+let Margin_12B = {
   marginBottom: '12px',
 };
-let HalfVerticalSpacing = {
+let Margin_6B = {
   marginBottom: '6px',
 };
 let Clickable = {
@@ -220,18 +225,20 @@ function Attack({ attack, onToggleActive, onToggleSilver, onDelete }) {
     <div style=${ActionEntry}>
       <button style=${{border: 'none', margin: 'none'}} onClick=${onToggleActive}>${attack.active?'▶️':'⏸️'}</button>
       <span>
-        <span style=${{ marginLeft: 5, marginRight: 5 }}>
+        <span style=${{ ...Margin_3L_3R }}>
           <span style=${{ ...Clickable }} onClick=${() => centerPlanet(attack.srcId)}>${finalSrc}</span>
-          <span style=${{ marginLeft: 3, marginRight: 3 }}>-></span>
+          <span style=${{ ...Margin_3L_3R }}>-></span>
           <span style=${{ ...Clickable }} onClick=${() => centerPlanet(attack.targetId)}>${finalTarget}</span>
         </span>
-        <span style=${{ marginLeft: 5, marginRight: 5 }}>
+        <span style=${{ ...Margin_3L_3R }}>
           <span>${`${attack.pcTrigger}%`}</span>
-          <span style=${{ marginLeft: 3, marginRight: 3 }}>-></span>
+          <span style=${{ ...Margin_3L_3R }}>-></span>
           <span>${`${attack.pcRemain}%`}</span>
         </span>
       </span>
-      <button onClick=${onToggleSilver}>${`${sendSilverStatusesIcon[attack.sendSilverStatus]}`}</button>
+      <span style=${{ ...Margin_3L_3R }}>
+        <button onClick=${onToggleSilver}>${`${sendSilverStatusesIcon[attack.sendSilverStatus]}`}</button>
+      </span>
       <button onClick=${onDelete}>X</button>
     </div>
   `;
@@ -262,7 +269,7 @@ function AddAttack({ startFiring, stopFiring, stopBeingFiredAt }) {
     <div style=${{ display: 'flex', flexDirection: 'column' }}>
       <div style=${{ display: 'flex' }}>
         <button
-          style=${VerticalSpacing}
+          style=${Margin_12B}
           onClick=${() => {
             setSource(planet);
           }}
@@ -270,18 +277,20 @@ function AddAttack({ startFiring, stopFiring, stopBeingFiredAt }) {
           Set Source
         </button>
         <span 
-          style=${source ? { ...Spacing, ...Clickable, marginRight: 'auto' } : {...Spacing, marginRight: 'auto'}} 
+          style=${source ? { ...Margin_12L_12R, ...Clickable, marginRight: 'auto' } : {...Margin_12L_12R, marginRight: 'auto'}} 
           onClick=${source? () => centerPlanet(source.locationId) : () => {}}
-          >${source ? getPlanetString(source.locationId) : '?????'}</span
         >
+          ${source ? getPlanetString(source.locationId) : PLANET_UNKNOWN}
+        </span>
       </div>
       <div style=${{ display: 'flex' }}>
-        <button style=${VerticalSpacing} onClick=${() => setTarget(planet)}>Set Target</button>
+        <button style=${Margin_12B} onClick=${() => setTarget(planet)}>Set Target</button>
         <span 
-        style=${target ? { ...Spacing, ...Clickable, marginRight: 'auto' } : {...Spacing, marginRight: 'auto'}} 
-        onClick=${target? () => centerPlanet(target.locationId) : () => {}}
-          >${target ? getPlanetString(target.locationId) : '?????'}</span
+          style=${target ? { ...Margin_12L_12R, ...Clickable, marginRight: 'auto' } : {...Margin_12L_12R, marginRight: 'auto'}} 
+          onClick=${target? () => centerPlanet(target.locationId) : () => {}}
         >
+          ${target ? getPlanetString(target.locationId) : PLANET_UNKNOWN}
+        </span>
       </div>
       <div style=${{marginBottom: 3}}>
         Trigger firing at this energy: <input type='range' min=${MIN_V} max=${MAX_V} step=${STEP_V} defaultValue=${pcTrigger} onChange=${e => setPcTrigger(parseInt(e.target.value))}/> ${pcTrigger}%
@@ -299,7 +308,7 @@ function AddAttack({ startFiring, stopFiring, stopBeingFiredAt }) {
       </div>
       <div>
         <button
-          style=${{...VerticalSpacing, width: 150}}
+          style=${{...Margin_12B, width: 150}}
           onClick=${() => target && source && startFiring({
             srcId: source.locationId,
             targetId: target.locationId,
@@ -319,22 +328,23 @@ function AddAttack({ startFiring, stopFiring, stopBeingFiredAt }) {
         style=${{fontSize: '90%'}}
       >
         <button
-          style=${{...VerticalSpacing, width: 80, marginRight: 10}}
+          style=${{...Margin_12B, width: 80, marginRight: 10}}
           onClick=${() => planet && stopFiring(planet.locationId)}
         >
           Stop Firing
         </button>
         <button
-          style=${{...VerticalSpacing, width: 93}}
+          style=${{...Margin_12B, width: 93}}
           onClick=${() => planet && stopBeingFiredAt(planet.locationId)}
         >
           Stop Being Fired At
         </button>
         <span 
-          style=${planet ? { ...Spacing, ...Clickable, marginRight: 'auto' } : {...Spacing, marginRight: 'auto'}} 
+          style=${planet ? { ...Margin_12L_12R, ...Clickable, marginRight: 'auto' } : {...Margin_12L_12R, marginRight: 'auto'}} 
           onClick=${planet ? () => centerPlanet(planet.locationId) : () => {}}
-          >${planet ? getPlanetString(planet.locationId) : '?????'}</span
         >
+          ${planet ? getPlanetString(planet.locationId) : PLANET_UNKNOWN}
+        </span>
       </div>
       <hr
         style=${{borderColor: 'grey', marginBottom: '10px'}}
@@ -371,7 +381,7 @@ function AttackList({ repeater }) {
     `;
   });
   return html`
-    <i style=${{ ...VerticalSpacing, display: 'block' }}>
+    <i style=${{ ...Margin_12B, display: 'block' }}>
       Auto-attack when source planet has enough energy!
     </i>
     <${AddAttack}
@@ -379,7 +389,7 @@ function AttackList({ repeater }) {
       stopFiring=${planetId => repeater.stopFiring(planetId)}
       stopBeingFiredAt=${planetId => repeater.stopBeingFiredAt(planetId)}
     />
-    <h1 style=${{...HalfVerticalSpacing, fontWeight: 'bold'}}>
+    <h1 style=${{...Margin_6B, fontWeight: 'bold'}}>
       Active (${attacks.reduce((acc, atk) => acc + (atk.active ? 1 : 0), 0)} / ${attacks.length})
       <button style=${{ float: 'right', marginLeft: 10 }} onClick=${() => {repeater.removeAllAttacks(); setAttacks([])}}>
         Clear All

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -19,7 +19,21 @@ import {
 
 import { getPlanetName } from 'https://cdn.skypack.dev/@darkforest_eth/procedural';
 
+
+// ----------------------------
+
+// USER CONFIGURABLE PARAMETERS
+
+// Stagger all the different attacks by this number of seconds, don't send all at once
 const STAGGER = 15;
+
+// Energy control – `let` is used here to sidestep any weird execution env problems
+let PERCENTAGE_TRIGGER = 75;  // What percentage energy will trigger a send?
+let PERCENTAGE_SEND = 50;     // How much energy will be sent? Ought to be less than PERCENTAGE_TRIGGER
+
+// ----------------------------
+
+
 const getPlanetString = (locationId) => {
   const planet = df.getPlanetWithId(locationId);
   if(!planet) return '?????'
@@ -61,9 +75,6 @@ function planetCurrentPercentEnergy(planet) {
   const estimatedEnergy = Math.floor(planet.energy - departures);
   return Math.floor((estimatedEnergy / planet.energyCap) * 100);
 }
-// I use `let` here to sidestep any weird execution env problems
-let PERCENTAGE_TRIGGER = 75;
-let PERCENTAGE_SEND = 50;
 class Repeater {
   constructor() {
     //@ts-ignore

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -140,7 +140,7 @@ class Repeater {
     if (attacksJSON) this.attacks = JSON.parse(attacksJSON);
   }
   addAttack(attack) {
-    let newAttacks = this.attacks.filter(a => a.srcId !== attack.srcId);
+    let newAttacks = this.attacks.filter(a => a.sourceId !== attack.sourceId);
     newAttacks = [attack, ...newAttacks];
     this.attacks = newAttacks;
     this.saveAttacks();
@@ -162,7 +162,7 @@ class Repeater {
     this.saveAttacks();
   }
   stopFiring(planetId) {
-    this.attacks = this.attacks.filter(a => a.srcId !== planetId);
+    this.attacks = this.attacks.filter(a => a.sourceId !== planetId);
     this.saveAttacks();
   }
   stopBeingFiredAt(planetId) {
@@ -176,8 +176,8 @@ class Repeater {
     });
   }
 }
-const ExecuteAttack = ({srcId, targetId, active, pcTrigger, pcRemain, sendSilverStatus}) => {
-  let srcPlanet = df.getPlanetWithId(srcId);
+const ExecuteAttack = ({sourceId, targetId, active, pcTrigger, pcRemain, sendSilverStatus}) => {
+  let srcPlanet = df.getPlanetWithId(sourceId);
   if (!srcPlanet) return;
   if (!active) return;
   // Needs updated check getUnconfirmedDepartingForces
@@ -192,7 +192,7 @@ const ExecuteAttack = ({srcId, targetId, active, pcTrigger, pcRemain, sendSilver
     if ( sendSilverStatus === SEND_ALL_SILVER || (sendSilverStatus === UPGRADE_FIRST && isFullRank(srcPlanet))) {
       silver = Math.round(srcPlanet.silver * (SILVER_SEND_PERCENT / 100));
     }
-    df.move(srcId, targetId, FORCES, silver);
+    df.move(sourceId, targetId, FORCES, silver);
   }
 };
 let Keyboard_Shortcut = {
@@ -230,7 +230,7 @@ function planetShort(locationId) {
   return locationId.substring(4, 9);
 }
 function Attack({ attack, onToggleActive, onToggleSilver, onDelete }) {
-  const srcString = getPlanetString(attack.srcId);
+  const srcString = getPlanetString(attack.sourceId);
   const targetString = getPlanetString(attack.targetId);
   const finalSrc = srcString.length > MAX_CHARS ? srcString.slice(0, MAX_CHARS - 3).concat('...') : srcString;
   const finalTarget = targetString.length > MAX_CHARS ? targetString.slice(0, MAX_CHARS - 3).concat('...') : targetString;
@@ -239,7 +239,7 @@ function Attack({ attack, onToggleActive, onToggleSilver, onDelete }) {
       <button style=${{border: 'none', margin: 'none'}} onClick=${onToggleActive}>${attack.active?'▶️':'⏸️'}</button>
       <span>
         <span style=${{ ...Margin_3L_3R }}>
-          <span style=${{ ...Clickable }} onClick=${() => centerPlanet(attack.srcId)}>${finalSrc}</span>
+          <span style=${{ ...Clickable }} onClick=${() => centerPlanet(attack.sourceId)}>${finalSrc}</span>
           <span style=${{ ...Margin_3L_3R }}>-></span>
           <span style=${{ ...Clickable }} onClick=${() => centerPlanet(attack.targetId)}>${finalTarget}</span>
         </span>
@@ -293,7 +293,7 @@ function AddAttack({ repeater, startFiring, stopFiring, stopBeingFiredAt }) {
   }, []);
 
   // Note: an attack is an object with this format:
-  // { srcId, targetId, active, pcTrigger, pcRemain, sendSilverStatus }
+  // { sourceId, targetId, active, pcTrigger, pcRemain, sendSilverStatus }
   // Each item is used to control a different aspect of the attack
 
   return html`
@@ -343,7 +343,7 @@ function AddAttack({ repeater, startFiring, stopFiring, stopBeingFiredAt }) {
         <button
           style=${{...Margin_12B, width: 150}}
           onClick=${() => target && source && startFiring({
-            srcId: source.locationId,
+            sourceId: source.locationId,
             targetId: target.locationId,
             active,
             pcTrigger,
@@ -446,7 +446,7 @@ const drawHighlights = plugin => {
   if (!planet || !planet.location) return;
   const selectedPlanetId = planet.locationId;
   const attacks = plugin.repeater.attacks;
-  const attacksSelectedIsSource = attacks.filter(a => a.srcId === selectedPlanetId);
+  const attacksSelectedIsSource = attacks.filter(a => a.sourceId === selectedPlanetId);
   const attacksSelectedIsTarget = attacks.filter(a => a.targetId === selectedPlanetId);
   if (!attacksSelectedIsSource.length && !attacksSelectedIsTarget.length) return;
   const getSawWave01 = (periodMs, planet) => {
@@ -479,8 +479,8 @@ const drawHighlights = plugin => {
   );
   drawHighlight(selectedPlanetId, `rgba(80, 80, 255, 0.7)`, -12000, 6, 0.7);
   attacksSelectedIsTarget.forEach(a => a.active
-    ? drawHighlight(a.srcId, `rgba(80, 255, 80, 0.5)`, 7000, 4, 0.8)
-    : drawHighlight(a.srcId, `rgba(140, 180, 40, 0.5)`, 7000, 3, 0.4)
+    ? drawHighlight(a.sourceId, `rgba(80, 255, 80, 0.5)`, 7000, 4, 0.8)
+    : drawHighlight(a.sourceId, `rgba(140, 180, 40, 0.5)`, 7000, 3, 0.4)
   );
 }
 

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -46,7 +46,6 @@ const getPlanetString = (locationId) => {
 };
 
 const getPlanetMaxRank = (planet) => {
-
   if (!planet) return 0;
   if(planet.planetType != PlanetType.PLANET) return 0;
   if (planet.spaceType === SpaceType.NEBULA) return 3;
@@ -131,21 +130,13 @@ class Repeater {
       if(i % STAGGER == Math.floor(Date.now() / 1000) % STAGGER) {
         const a = this.attacks[i];
         ExecuteAttack(a.srcId, a.targetId);
-
       }
     }
-    
-    // this?.attacks?.forEach((a) => {
-    //   ExecuteAttack(a.srcId, a.targetId);
-    // });
   }
 }
 const ExecuteAttack = (srcId, targetId) => {
   let srcPlanet = df.getPlanetWithId(srcId);
-  if (!srcPlanet) {
-    // Well shit
-    return;
-  }
+  if (!srcPlanet) return;
   // Needs updated check getUnconfirmedDepartingForces
   const departingForces = unconfirmedDepartures(srcPlanet);
   const TRIGGER_AMOUNT = Math.floor((srcPlanet.energyCap * PERCENTAGE_TRIGGER) / 100);

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -90,16 +90,18 @@ class Repeater {
     }
     this.attacks = [];
     this.account = df.getAccount();
-    if (localStorage.getItem(`repeatAttacks-${this.account}`)) {
-      // @ts-ignore
-      this.attacks = JSON.parse(localStorage.getItem(`repeatAttacks-${this.account}`));
-    }
+    this.loadAttacks();
     this.intervalId = window.setInterval(this.coreLoop.bind(this), 1000);
     //@ts-ignore
     window.__CORELOOP__.push(this.intervalId);
   }
   saveAttacks() {
     localStorage.setItem(`repeatAttacks-${this.account}`, JSON.stringify(this.attacks));
+  }
+  loadAttacks() {
+    const attacksJSON = localStorage.getItem(`repeatAttacks-${this.account}`);
+    // @ts-ignore
+    if (attacksJSON) this.attacks = JSON.parse(attacksJSON);
   }
   addAttack(srcId, targetId, pcTrigger, pcRemain, sendSilver) {
     let newAttacks = this.attacks.filter(item => item.srcId !== srcId);

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -1,3 +1,10 @@
+// Repeat Attack
+//
+// Auto-attack when source planet has enough energy!
+//
+// original author: TBC
+// enhancements in 2022: https://twitter.com/davidryan59
+
 //@ts-ignore
 import {
   PlanetType,
@@ -20,10 +27,8 @@ import {
 import { getPlanetName } from 'https://cdn.skypack.dev/@darkforest_eth/procedural';
 
 
-// ----------------------------
-
-// USER CONFIGURABLE PARAMETERS
-// `let` is used here to sidestep any weird execution env problems
+// ----------------------------------------
+// User Configurable Options
 
 // Control how much energy gets sent, and when
 let DEFAULT_PERCENTAGE_TRIGGER = 75;  // What percentage energy will trigger a send?
@@ -42,7 +47,8 @@ let STEP_V = 5; // Set step size for sliders
 // Other controls
 let SILVER_SEND_PERCENT = 99;  // Sends this proportion of silver from the source planet
 
-// ----------------------------
+// Note - `let` is used in this plugin to sidestep any weird execution env problems
+// ----------------------------------------
 
 
 const sendSilverStatuses = [

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -39,7 +39,7 @@ let STAGGER_S = 15;  // Over what number of seconds will all repeat attacks happ
 
 // UI controls
 let MAX_CHARS = 15;  // How many letters of planet name to display?
-let WIDTH_PX = 430;  // What is the width of plugin window?
+let WIDTH_PX = 440;  // What is the width of plugin window?
 let MIN_V = 10; // Set minimum values for sliders
 let MAX_V = 90; // Set maximum values for sliders
 let STEP_V = 5; // Set step size for sliders

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -32,6 +32,10 @@ let DEFAULT_PERCENTAGE_REMAIN = 25;   // How much energy will remain after sendi
 // Stagger all the different attacks by this number of seconds, don't send all at once
 let STAGGER_S = 15;  // Over what number of seconds will all repeat attacks happen once?
 
+// UI controls
+let MAX_CHARS = 14;  // How many letters of planet name to display?
+let WIDTH_PX = 430;  // What is the width of plugin window?
+
 // ----------------------------
 
 
@@ -179,8 +183,8 @@ function planetShort(locationId) {
 function Attack({ attack, onDelete }) {
   const srcString = getPlanetString(attack.srcId);
   const targetString = getPlanetString(attack.targetId);
-  const finalSrc = srcString.length > 16 ? srcString.slice(0, 13).concat('...') : srcString;
-  const finalTarget = targetString.length > 16 ? targetString.slice(0, 13).concat('...') : targetString;
+  const finalSrc = srcString.length > MAX_CHARS ? srcString.slice(0, MAX_CHARS - 3).concat('...') : srcString;
+  const finalTarget = targetString.length > MAX_CHARS ? targetString.slice(0, MAX_CHARS - 3).concat('...') : targetString;
   return html`
     <div style=${ActionEntry}>
       <span>
@@ -192,6 +196,7 @@ function Attack({ attack, onDelete }) {
           >${finalTarget}</span
         ></span
       >
+      ${`${attack.pcTrigger}% -> ${attack.pcRemain}% ${attack.sendSilver?'$':'-'}`}
       <button onClick=${onDelete}>X</button>
     </div>
   `;
@@ -352,7 +357,7 @@ class Plugin {
    */
   async render(container) {
     this.container = container;
-    container.style.width = '400px';
+    container.style.width = `${WIDTH_PX}px`;
     this.root = render(html`<${App} repeater=${this.repeater} />`, container);
   }
   /**

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -247,8 +247,14 @@ function AddAttack({ startFiring, stopFiring, stopBeingFiredAt }) {
           >${target ? getPlanetString(target.locationId) : '?????'}</span
         >
       </div>
-      <div style=${{marginBottom: 5}}>
-        Send Silver? <input type='checkbox' checked=${sendSilver} onChange=${() => setSendSilver(!sendSilver)}/>
+      <div>
+        Send Silver after upgrading? <input type='checkbox' checked=${sendSilver} onChange=${() => setSendSilver(!sendSilver)}/>
+      </div>
+      <div>
+        Trigger firing at this energy: <input type='range' min=2 max=98 step=2 defaultValue=${pcTrigger} onChange=${e => setPcTrigger(parseInt(e.target.value))}/> ${pcTrigger}%
+      </div>
+      <div style=${{marginBottom: 10}}>
+        Remaining energy after firing: <input type='range' min=2 max=98 step=2 defaultValue=${pcRemain} onChange=${e => setPcRemain(parseInt(e.target.value))}/> ${pcRemain}%
       </div>
       <div>
         <button

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -29,7 +29,7 @@ const STAGGER = 15;
 
 // Energy control – `let` is used here to sidestep any weird execution env problems
 let PERCENTAGE_TRIGGER = 75;  // What percentage energy will trigger a send?
-let PERCENTAGE_SEND = 50;     // How much energy will be sent? Ought to be less than PERCENTAGE_TRIGGER
+let PERCENTAGE_REMAIN = 25;   // How much energy will remain after sending?
 
 // ----------------------------
 
@@ -143,7 +143,7 @@ const ExecuteAttack = (srcId, targetId) => {
   const FUZZY_ENERGY = Math.floor(srcPlanet.energy - departingForces); //Best estimate of how much energy is ready to send
   if (FUZZY_ENERGY > TRIGGER_AMOUNT) {
     const overflow_send =
-      planetCurrentPercentEnergy(srcPlanet) - (PERCENTAGE_TRIGGER - PERCENTAGE_SEND);
+      planetCurrentPercentEnergy(srcPlanet) - PERCENTAGE_REMAIN;
     const FORCES = Math.floor((srcPlanet.energyCap * overflow_send) / 100);
     let silver = 0;
     if (isFullRank(srcPlanet)) {

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -329,8 +329,8 @@ function AttackList({ repeater }) {
     `;
   });
   return html`
-    <i style=${{ ...VerticalSpacing, display: 'block' }}
-      >Auto-attack when source planet >75% energy. Will send all planet silver
+    <i style=${{ ...VerticalSpacing, display: 'block' }}>
+      Auto-attack when source planet has enough energy!
     </i>
     <${AddAttack}
       startFiring=${attack => repeater.addAttack(attack)}

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -101,8 +101,8 @@ class Repeater {
     localStorage.setItem(`repeatAttacks-${this.account}`, JSON.stringify(this.attacks));
   }
   addAttack(srcId, targetId) {
-    const newAttacks = this.attacks.filter(item => item.srcId !== srcId);
-    newAttacks.push({ srcId, targetId });
+    let newAttacks = this.attacks.filter(item => item.srcId !== srcId);
+    newAttacks = [{ srcId, targetId }, ...newAttacks];
     this.attacks = newAttacks;
     this.saveAttacks();
   }

--- a/embedded_plugins/Repeat-Attack.js
+++ b/embedded_plugins/Repeat-Attack.js
@@ -44,6 +44,10 @@ let MIN_V = 10; // Set minimum values for sliders
 let MAX_V = 90; // Set maximum values for sliders
 let STEP_V = 5; // Set step size for sliders
 
+// Keyboard shortcuts
+const KEY_SET_SOURCE = 'v';
+const KEY_SET_TARGET = 'b';
+
 // Other controls
 let SILVER_SEND_PERCENT = 99;  // Sends this proportion of silver from the source planet
 
@@ -191,6 +195,10 @@ const ExecuteAttack = ({srcId, targetId, active, pcTrigger, pcRemain, sendSilver
     df.move(srcId, targetId, FORCES, silver);
   }
 };
+let Keyboard_Shortcut = {
+  fontSize: '85%',
+  color: 'rgba(220, 180, 128, 1)'
+};
 let Margin_3L_3R = {
   marginLeft: '3px',
   marginRight: '3px',
@@ -267,6 +275,22 @@ function AddAttack({ repeater, startFiring, stopFiring, stopBeingFiredAt }) {
       window.removeEventListener('click', onClick);
     };
   }, []);
+  useLayoutEffect(() => {
+    let onKeyUp = e => {
+      switch (e.key) {
+        case KEY_SET_SOURCE:
+          setSource(ui.getSelectedPlanet());
+          break;
+        case KEY_SET_TARGET:
+          setTarget(ui.getSelectedPlanet());
+          break;
+      }
+    };
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
 
   // Note: an attack is an object with this format:
   // { srcId, targetId, active, pcTrigger, pcRemain, sendSilverStatus }
@@ -281,7 +305,7 @@ function AddAttack({ repeater, startFiring, stopFiring, stopBeingFiredAt }) {
             setSource(planet);
           }}
         >
-          Set Source
+          Set Source <span style=${Keyboard_Shortcut}>[${KEY_SET_SOURCE}]</span>
         </button>
         <span 
           style=${source ? { ...Margin_12L_12R, ...Clickable, marginRight: 'auto' } : {...Margin_12L_12R, marginRight: 'auto'}} 
@@ -291,7 +315,9 @@ function AddAttack({ repeater, startFiring, stopFiring, stopBeingFiredAt }) {
         </span>
       </div>
       <div style=${{ display: 'flex' }}>
-        <button style=${Margin_12B} onClick=${() => setTarget(planet)}>Set Target</button>
+        <button style=${Margin_12B} onClick=${() => setTarget(planet)}>
+          Set Target <span style=${Keyboard_Shortcut}>[${KEY_SET_TARGET}]</span>
+        </button>
         <span 
           style=${target ? { ...Margin_12L_12R, ...Clickable, marginRight: 'auto' } : {...Margin_12L_12R, marginRight: 'auto'}} 
           onClick=${target? () => centerPlanet(target.locationId) : () => {}}


### PR DESCRIPTION
- Energy and silver options are on a per-source-planet basis now
- Energy trigger and energy remaining after firing can be customised per planet
- 3 different silver sending options
- Also some refactoring of the plugin. Each attack has 5 items stored in it now, rather than 2.