### PR TITLE
DFD-37 portal home official grand prix

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-timeago": "^6.2.1",
     "sortablejs": "^1.10.2",
     "styled-components": "^5.3.3",
+    "swr": "^1.3.0",
     "ts-dedent": "^2.0.0",
     "uuid": "^8.3.2"
   },

--- a/src/Backend/Network/Blockchain.ts
+++ b/src/Backend/Network/Blockchain.ts
@@ -22,7 +22,7 @@ export async function loadDiamondContract<T extends Contract>(
 /**
  * Loads the faucet contract, which is responsible for dripping funds to players
  */
- export async function loadFaucetContract<T extends Contract>(
+export async function loadFaucetContract<T extends Contract>(
   address: string,
   provider: providers.JsonRpcProvider,
   signer?: Wallet
@@ -35,7 +35,7 @@ export async function loadDiamondContract<T extends Contract>(
 /**
  * Loads the init contract, which is responsible for initializing lobbies
  */
- export async function loadInitContract<T extends Contract>(
+export async function loadInitContract<T extends Contract>(
   address: string,
   provider: providers.JsonRpcProvider,
   signer?: Wallet
@@ -45,9 +45,8 @@ export async function loadDiamondContract<T extends Contract>(
   return createContract<T>(address, abi, provider, signer);
 }
 
-
 export function getEthConnection(): Promise<EthConnection> {
-  const isProdNetwork = (NETWORK.toString() !== 'localhost' && NETWORK.toString() !== 'hardhat');
+  const isProdNetwork = NETWORK.toString() !== 'localhost' && NETWORK.toString() !== 'hardhat';
   const defaultUrl = process.env.DEFAULT_RPC as string;
 
   let url: string;
@@ -62,7 +61,8 @@ export function getEthConnection(): Promise<EthConnection> {
   console.log(`is production network: ${isProdNetwork}`);
   console.log(`client build: ${process.env.NODE_ENV}`);
   console.log(`webserver url: ${process.env.DF_WEBSERVER_URL}`);
-  // console.log(`faucet url: ${process.env.DFDAO_WEBSERVER_URL}`);
+  console.log(`faucet url: ${process.env.FAUCET_URL}`);
 
+  console.log(`dfdao url: ${process.env.DFDAO_WEBSERVER_URL} `);
   return createEthConnection(url);
 }

--- a/src/Backend/Network/UtilityServerAPI.ts
+++ b/src/Backend/Network/UtilityServerAPI.ts
@@ -328,3 +328,5 @@ export const disconnectTwitter = async (
     return false;
   }
 };
+
+export const fetcher = (...args: any) => fetch(args).then((res) => res.json());

--- a/src/Frontend/Views/Portal/Components/OfficialGameBanner.tsx
+++ b/src/Frontend/Views/Portal/Components/OfficialGameBanner.tsx
@@ -13,7 +13,7 @@ import { MinimalButton } from '../PortalMainView';
 
 export const OfficialGameBanner: React.FC<{
   title?: string;
-  description?: string;
+  description?: string | JSX.Element;
   disabled?: boolean;
   link: string;
   imageUrl: string;

--- a/src/Frontend/Views/Portal/MapDetails.tsx
+++ b/src/Frontend/Views/Portal/MapDetails.tsx
@@ -19,7 +19,7 @@ export const getRoundID = async (configHash: string): Promise<number> => {
   const searchParams = new URLSearchParams({
     configHash: configHash,
   });
-  const selectedRoundID = await fetch(`http://localhost:3000/rounds?${searchParams}`, {
+  const selectedRoundID = await fetch(`${process.env.DF_WEBSERVER_URL}/rounds?${searchParams}`, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },
   });
@@ -48,7 +48,7 @@ export function MapDetails({
   useEffect(() => {
     async function getConfigDescription(configHash: string) {
       const roundId = await getRoundID(configHash);
-      const res = await fetch(`http://localhost:3000/rounds/${roundId}`, {
+      const res = await fetch(`${process.env.DFDAO_WEBSERVER_URL}/rounds/${roundId}`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
       });

--- a/src/Frontend/Views/Portal/MapDetails.tsx
+++ b/src/Frontend/Views/Portal/MapDetails.tsx
@@ -1,4 +1,3 @@
-import { getConfigName } from '@darkforest_eth/procedural';
 import { Leaderboard, LiveMatch } from '@darkforest_eth/types';
 import React, { useEffect, useState } from 'react';
 import { loadArenaLeaderboard } from '../../../Backend/Network/GraphApi/ArenaLeaderboardApi';
@@ -14,19 +13,8 @@ import { LiveMatches } from '../Leaderboards/LiveMatches';
 import { TabbedView } from '../TabbedView';
 import { ConfigDetails } from './ConfigDetails';
 import { FindMatch } from './FindMatch';
-
-export const getRoundID = async (configHash: string): Promise<number> => {
-  const searchParams = new URLSearchParams({
-    configHash: configHash,
-  });
-  const selectedRoundID = await fetch(`${process.env.DF_WEBSERVER_URL}/rounds?${searchParams}`, {
-    method: 'GET',
-    headers: { 'Content-Type': 'application/json' },
-  });
-  const fetchedText = await selectedRoundID.text();
-  const fetchedId = JSON.parse(fetchedText).body[0].id;
-  return fetchedId;
-};
+import useSWR from 'swr';
+import { fetcher } from '../../../Backend/Network/UtilityServerAPI';
 
 export function MapDetails({
   configHash,
@@ -40,22 +28,16 @@ export function MapDetails({
   const [leaderboardError, setLeaderboardError] = useState<Error | undefined>();
   const [liveMatches, setLiveMatches] = useState<LiveMatch | undefined>();
   const [liveMatchError, setLiveMatchError] = useState<Error | undefined>();
-  const [description, setDescription] = useState<string>('');
 
+  const { data: data, error } = useSWR(
+    `${process.env.DFDAO_WEBSERVER_URL}/rounds/${configHash}`,
+    fetcher
+  );
+  const parsedData = data ? JSON.parse(data) : undefined;
   const numSpawnPlanets = config?.ADMIN_PLANETS.filter((p) => p.isSpawnPlanet).length ?? 0;
   const hasWhitelist = config?.WHITELIST_ENABLED ?? true;
 
   useEffect(() => {
-    async function getConfigDescription(configHash: string) {
-      const roundId = await getRoundID(configHash);
-      const res = await fetch(`${process.env.DFDAO_WEBSERVER_URL}/rounds/${roundId}`, {
-        method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      const text = await res.text();
-      return JSON.parse(text).body.description;
-    }
-
     setLeaderboard(undefined);
     setLiveMatches(undefined);
     if (configHash) {
@@ -83,11 +65,6 @@ export function MapDetails({
           console.log(e);
           setLiveMatchError(e);
         });
-      getConfigDescription(configHash).then((x) => {
-        if (x) {
-          setDescription(x);
-        }
-      });
     }
   }, [configHash]);
 
@@ -105,7 +82,7 @@ export function MapDetails({
         overflowY: 'auto',
       }}
     >
-      {description.length > 0 && (
+      {parsedData?.description?.length > 0 && (
         <div
           style={{
             margin: '2rem auto',
@@ -124,7 +101,7 @@ export function MapDetails({
               opacity: '70%',
             }}
           >
-            {description}
+            {parsedData.description}
           </span>
         </div>
       )}

--- a/src/Frontend/Views/Portal/PortalHomeView.tsx
+++ b/src/Frontend/Views/Portal/PortalHomeView.tsx
@@ -1,35 +1,85 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { TimeUntil } from '../../Components/TimeUntil';
 import { competitiveConfig, tutorialConfig } from '../../Utils/constants';
 import { OfficialGameBanner } from './Components/OfficialGameBanner';
 
+const dummyData = [
+  {
+    description: 'fjkgdsahghdkflhkaasdfsdf',
+    startTime: 1659383103265,
+    endTime: 1659555903265,
+    configHash: '0x55911a7c9a236e6cdc1f4e8b63362668eff237a9d0d3c242ff1f5c27901b079d',
+    id: 2,
+  },
+  {
+    description: 'A short description of the round ruleset. Blah blah blah. Rules rules rules.',
+    startTime: 1659713036400,
+    endTime: 1660577036400,
+    configHash: '0xfe719a3cfccf2bcfa23f71f0af80a931eda4f4197331828d728b7505a6156930',
+    id: 3,
+  },
+];
+
 export const PortalHomeView: React.FC<{}> = () => {
+  const [rounds, setRounds] = useState<
+    {
+      description: string;
+      startTime: number;
+      endTime: number;
+      configHash: string;
+      id: number;
+    }[]
+  >();
+
+  const [current, setCurrent] = useState<boolean>(false);
+  const [finalTime, setFinalTime] = useState<number>();
+  const [roundConfig, setRoundConfig] = useState<string>();
   useEffect(() => {
     const fetchRounds = async () => {
-      await fetch(`${process.env.DFDAO_WEBSERVER_URL}/rounds`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
+      // await fetch(`${process.env.DFDAO_WEBSERVER_URL}/rounds`, {
+      //   method: 'GET',
+      //   headers: {
+      //     'Content-Type': 'application/json',
+      //   },
+      // });
+      const data = dummyData.sort((a, b) => a.startTime - b.endTime);
+
+      setRounds(data);
+      const now = Date.now();
+      console.log(now);
+      for (const round of data) {
+        if (round.startTime > now) {
+          setFinalTime(round.startTime);
+          setRoundConfig(round.configHash);
+          return;
+        }
+
+        if (round.startTime < now && round.endTime > now) {
+          setFinalTime(round.endTime);
+          setCurrent(true);
+          setRoundConfig(round.configHash);
+          return;
+        }
+      }
     };
-    // fetchRounds();
+
+    fetchRounds();
   }, []);
 
-  const current = false;
-  const nextRound = new Date('August 5, 2022 03:24:00').getTime();
   const title = current ? 'Race the Grand Prix' : "Practice Last Week's Grand Prix";
-  const description = current ? (
+  const description = !finalTime ? (
+    <>No round scheduled</>
+  ) : current ? (
     <>
-      This round ends in <TimeUntil timestamp={nextRound} ifPassed='zero seconds!' />
+      This round ends in <TimeUntil timestamp={finalTime} ifPassed='zero seconds!' />
     </>
   ) : (
     <>
-      Next round starts in <TimeUntil timestamp={nextRound} ifPassed='zero seconds!' />
+      Next round starts in <TimeUntil timestamp={finalTime} ifPassed='zero seconds!' />
     </>
   );
-  const link = `/portal/map/${competitiveConfig}`;
+  const link = `/portal/map/${roundConfig}`;
 
   return (
     <Container>

--- a/src/Frontend/Views/Portal/PortalHomeView.tsx
+++ b/src/Frontend/Views/Portal/PortalHomeView.tsx
@@ -38,18 +38,20 @@ export const PortalHomeView: React.FC<{}> = () => {
   const [roundConfig, setRoundConfig] = useState<string>();
   useEffect(() => {
     const fetchRounds = async () => {
-      // await fetch(`${process.env.DFDAO_WEBSERVER_URL}/rounds`, {
+      // const data = await fetch(`${process.env.DFDAO_WEBSERVER_URL}/rounds`, {
       //   method: 'GET',
       //   headers: {
       //     'Content-Type': 'application/json',
       //   },
       // });
-      const data = dummyData.sort((a, b) => a.startTime - b.endTime);
+      const data = dummyData;
 
-      setRounds(data);
+      const sortedData = data.sort((a, b) => a.startTime - b.endTime);
+
+      setRounds(sortedData);
       const now = Date.now();
-      console.log(now);
-      for (const round of data) {
+
+      for (const round of sortedData) {
         if (round.startTime > now) {
           setFinalTime(round.startTime);
           setRoundConfig(round.configHash);
@@ -67,7 +69,6 @@ export const PortalHomeView: React.FC<{}> = () => {
 
     fetchRounds();
   }, []);
-
   const title = current ? 'Race the Grand Prix' : "Practice Last Week's Grand Prix";
   const description = !finalTime ? (
     <>No round scheduled</>

--- a/src/Frontend/Views/Portal/PortalHomeView.tsx
+++ b/src/Frontend/Views/Portal/PortalHomeView.tsx
@@ -1,18 +1,33 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
+import { TimeUntil } from '../../Components/TimeUntil';
 import { competitiveConfig, tutorialConfig } from '../../Utils/constants';
-import { loadRecentMaps, MapInfo } from '../../../Backend/Network/GraphApi/MapsApi';
 import { OfficialGameBanner } from './Components/OfficialGameBanner';
 
 export const PortalHomeView: React.FC<{}> = () => {
+  const current = false;
+  const nextRound = new Date('August 5, 2022 03:24:00').getTime();
+  const title = current ? 'Race the Grand Prix' : "Practice Last Week's Grand Prix";
+  const description = current ? (
+    <>
+      This round ends in <TimeUntil timestamp={nextRound} ifPassed='zero seconds!' />
+    </>
+  ) : (
+    <>
+      Next round starts in <TimeUntil timestamp={nextRound} ifPassed='zero seconds!' />
+    </>
+  );
+  const link = `/portal/map/${competitiveConfig}`;
+
   return (
     <Container>
       <Content>
         <span style={{ fontSize: '3em', gridColumn: '1/7' }}>Welcome to Dark Forest Arena!</span>
         <OfficialGameBanner
-          title='Play Galactic League'
+          title={title}
+          description={description}
           style={{ gridColumn: '1 / 5', gridRow: '2/4' }}
-          link={`/portal/map/${competitiveConfig}`}
+          link={link}
           imageUrl='/public/img/deathstar.png'
         />
         <OfficialGameBanner

--- a/src/Frontend/Views/Portal/PortalHomeView.tsx
+++ b/src/Frontend/Views/Portal/PortalHomeView.tsx
@@ -1,10 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { TimeUntil } from '../../Components/TimeUntil';
 import { competitiveConfig, tutorialConfig } from '../../Utils/constants';
 import { OfficialGameBanner } from './Components/OfficialGameBanner';
 
 export const PortalHomeView: React.FC<{}> = () => {
+  useEffect(() => {
+    const fetchRounds = async () => {
+      await fetch(`${process.env.DFDAO_WEBSERVER_URL}/rounds`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    };
+    // fetchRounds();
+  }, []);
+
   const current = false;
   const nextRound = new Date('August 5, 2022 03:24:00').getTime();
   const title = current ? 'Race the Grand Prix' : "Practice Last Week's Grand Prix";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,6 +120,7 @@ module.exports = {
       DF_WEBSERVER_URL: null,
       DF_TWITTER_URL: null,
       FAUCET_URL: null,
+      DFDAO_WEBSERVER_URL: null,
     }),
     new HtmlWebpackPlugin({
       template: './index.html',


### PR DESCRIPTION
Description: client reads from the Cloudflare backend to display 1. the current round and countdown to end of round OR a previous round and countdown to next round and 2. A description of the ruleset for an official round

![image](https://user-images.githubusercontent.com/71292860/183128786-13632776-5c82-4021-ac02-d7e22edf1e8b.png)
![image](https://user-images.githubusercontent.com/71292860/183128813-95901db3-af60-4464-abf0-2c6a0545ebe8.png)

To test: 
- [x] remove all rounds from the database and make sure the button is disabled, and there is no countdown
- [x] add a past round and make sure the button is enabled to that round, and there is no countdown
- [x] add a future round and make sure the countdown ends at the start of that round
- [x] add a current round and make sure the button is enabled to that round and there is a countdown to the end of the round
- [x] make sure that the description of a round is properly rendered in the map details page
