### PR TITLE
DFD-18 history page

### DIFF
--- a/src/Frontend/Views/Portal/PortalHistoryView.tsx
+++ b/src/Frontend/Views/Portal/PortalHistoryView.tsx
@@ -33,7 +33,7 @@ export const PortalHistoryView: React.FC<{}> = ({}) => {
         configHash: round.configHash,
         name: getConfigName(round.configHash),
         startTime: round.startTime,
-        endTIme: round.endTime,
+        endTime: round.endTime,
         winner: round.winner,
       };
     });

--- a/src/Frontend/Views/Portal/PortalHistoryView.tsx
+++ b/src/Frontend/Views/Portal/PortalHistoryView.tsx
@@ -41,7 +41,6 @@ export const PortalHistoryView: React.FC<{}> = ({}) => {
     }
   }, [adminData]);
 
-  console.log(rounds);
   const addressToTwitter = (address: string) => {
     const foundTwitter = Object.entries(twitters).find((t) => t[1] == address.toLowerCase().trim());
     if (foundTwitter) {

--- a/src/Frontend/Views/Portal/PortalHistoryView.tsx
+++ b/src/Frontend/Views/Portal/PortalHistoryView.tsx
@@ -1,5 +1,5 @@
 import { getConfigName } from '@darkforest_eth/procedural';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import useSWR from 'swr';
@@ -24,20 +24,23 @@ export interface RoundHistoryItem {
 export const PortalHistoryView: React.FC<{}> = ({}) => {
   const history = useHistory();
   const twitters = useTwitters() as Object;
-
   const { data: adminData, error } = useSWR(`${process.env.DFDAO_WEBSERVER_URL}/rounds`, fetcher);
-  let rounds = undefined;
-  if (adminData) {
-    rounds = adminData.map((round: any) => {
-      return {
-        configHash: round.configHash,
-        name: getConfigName(round.configHash),
-        startTime: round.startTime,
-        endTime: round.endTime,
-        winner: round.winner,
-      };
-    });
-  }
+  const rounds = useMemo(() => {
+    if (adminData) {
+      return adminData.map((round: RoundHistoryItem & { endTime: number }) => {
+        return {
+          configHash: round.configHash,
+          name: getConfigName(round.configHash),
+          startTime: round.startTime,
+          endTime: round.endTime,
+          winner: round.winner,
+        };
+      });
+    } else {
+      return [];
+    }
+  }, [adminData]);
+
   console.log(rounds);
   const addressToTwitter = (address: string) => {
     const foundTwitter = Object.entries(twitters).find((t) => t[1] == address.toLowerCase().trim());

--- a/src/Frontend/Views/Portal/PortalHistoryView.tsx
+++ b/src/Frontend/Views/Portal/PortalHistoryView.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import useSWR from 'swr';
 import { fetcher } from '../../../Backend/Network/UtilityServerAPI';
 import { Link } from '../../Components/CoreUI';
+import { MythicLabelText } from '../../Components/Labels/MythicLabel';
 import dfstyles from '../../Styles/dfstyles';
 import { useTwitters } from '../../Utils/AppHooks';
 import { formatStartTime } from '../../Utils/TimeUtils';
@@ -49,7 +50,9 @@ export const PortalHistoryView: React.FC<{}> = ({}) => {
 
   return (
     <Container>
-      <Header>Previous Grand Prix Rounds</Header>
+      <Header>
+        <MythicLabelText text='Previous Grand Prix Rounds'></MythicLabelText>
+      </Header>
       {error ? (
         <span>Unable to load Grand Prix round history.</span>
       ) : (
@@ -72,7 +75,7 @@ export const PortalHistoryView: React.FC<{}> = ({}) => {
                       history.push(`/portal/map/${historyItem.configHash}`);
                     }}
                   >
-                    <TimelineItem>{formatStartTime(historyItem.startTime)}</TimelineItem>
+                    <TimelineItem>{formatStartTime(historyItem.startTime / 1000)}</TimelineItem>
                     <TimelineItem>{historyItem.name}</TimelineItem>
                     <TimelineItem>
                       {historyItem.winner !== undefined && historyItem.winner !== '' ? (

--- a/src/Frontend/Views/Portal/PortalHomeView.tsx
+++ b/src/Frontend/Views/Portal/PortalHomeView.tsx
@@ -72,7 +72,6 @@ export const PortalHomeView: React.FC<{}> = () => {
           style={{ gridColumn: '5 / 7', gridRow: '2/3' }}
           link='/portal/history'
           imageUrl='/public/img/deathstar.png'
-          disabled
         />
         <OfficialGameBanner
           title='Find a match'


### PR DESCRIPTION
Description: Properly connects the official round history page to our server, enables round history button on home page, and restyles title to mythic label
![image](https://user-images.githubusercontent.com/71292860/183484219-aba5fe40-15e8-47a1-ac64-d46024decaa7.png)

To test:
- [x] Add a new map to the database and verify it renders correctly
- [x] Ensure map link links to the proper map page