### PR TITLE
DFD-81 Enable History Btn

### DIFF
--- a/src/Frontend/Views/Portal/PortalHistoryView.tsx
+++ b/src/Frontend/Views/Portal/PortalHistoryView.tsx
@@ -58,43 +58,49 @@ export const PortalHistoryView: React.FC<{}> = ({}) => {
       {error ? (
         <span>Unable to load Grand Prix round history.</span>
       ) : (
-        <TimelineContainer>
-          <thead>
-            <tr>
-              <TimelineHeader>Started</TimelineHeader>
-              <TimelineHeader>Name</TimelineHeader>
-              <TimelineHeader>Winner</TimelineHeader>
-            </tr>
-          </thead>
-          <tbody>
-            {rounds &&
-              rounds
-                .filter((round: any) => round.startTime < Date.now())
-                .map((historyItem: RoundHistoryItem) => (
-                  <TimelineRow
-                    key={historyItem.configHash}
-                    onClick={() => {
-                      history.push(`/portal/map/${historyItem.configHash}`);
-                    }}
-                  >
-                    <TimelineItem>{formatStartTime(historyItem.startTime / 1000)}</TimelineItem>
-                    <TimelineItem>{historyItem.name}</TimelineItem>
-                    <TimelineItem>
-                      {historyItem.winner !== undefined && historyItem.winner !== '' ? (
-                        <Link to={`https://twitter.com/${addressToTwitter(historyItem.winner)}`}>
-                          {addressToTwitter(historyItem.winner)}
-                        </Link>
-                      ) : (
-                        'None'
-                      )}
-                    </TimelineItem>
-                    <TimelineItem>
-                      <HoverIcon />
-                    </TimelineItem>
-                  </TimelineRow>
-                ))}
-          </tbody>
-        </TimelineContainer>
+        <>
+          {(rounds && rounds.length) > 0 ? (
+            <TimelineContainer>
+              <thead>
+                <tr>
+                  <TimelineHeader>Started</TimelineHeader>
+                  <TimelineHeader>Name</TimelineHeader>
+                  <TimelineHeader>Winner</TimelineHeader>
+                </tr>
+              </thead>
+              <tbody>
+                {' '}
+                {rounds
+                  .filter((round: any) => round.startTime < Date.now())
+                  .map((historyItem: RoundHistoryItem) => (
+                    <TimelineRow
+                      key={historyItem.configHash}
+                      onClick={() => {
+                        history.push(`/portal/map/${historyItem.configHash}`);
+                      }}
+                    >
+                      <TimelineItem>{formatStartTime(historyItem.startTime / 1000)}</TimelineItem>
+                      <TimelineItem>{historyItem.name}</TimelineItem>
+                      <TimelineItem>
+                        {historyItem.winner !== undefined && historyItem.winner !== '' ? (
+                          <Link to={`https://twitter.com/${addressToTwitter(historyItem.winner)}`}>
+                            {addressToTwitter(historyItem.winner)}
+                          </Link>
+                        ) : (
+                          'None'
+                        )}
+                      </TimelineItem>
+                      <TimelineItem>
+                        <HoverIcon />
+                      </TimelineItem>
+                    </TimelineRow>
+                  ))}
+              </tbody>
+            </TimelineContainer>
+          ) : (
+            <span>No Previous Rounds</span>
+          )}
+        </>
       )}
     </Container>
   );

--- a/src/Frontend/Views/Portal/PortalHistoryView.tsx
+++ b/src/Frontend/Views/Portal/PortalHistoryView.tsx
@@ -59,7 +59,7 @@ export const PortalHistoryView: React.FC<{}> = ({}) => {
         <span>Unable to load Grand Prix round history.</span>
       ) : (
         <>
-          {(rounds && rounds.length) > 0 ? (
+          {rounds && rounds.length > 0 ? (
             <TimelineContainer>
               <thead>
                 <tr>

--- a/src/Frontend/Views/Portal/PortalHomeView.tsx
+++ b/src/Frontend/Views/Portal/PortalHomeView.tsx
@@ -72,7 +72,6 @@ export const PortalHomeView: React.FC<{}> = () => {
           style={{ gridColumn: '5 / 7', gridRow: '2/3' }}
           link='/portal/history'
           imageUrl='/public/img/screenshots/pickles.png'
-          disabled
         />
         <OfficialGameBanner
           title='Find a match'


### PR DESCRIPTION
Description: Enables the history page button on the portal homepage. Also handles case in which there are no previous games in existence.
![image](https://user-images.githubusercontent.com/71292860/184675482-6f9a924c-b01b-4b1d-b88c-4ea4cab5056a.png)
![image](https://user-images.githubusercontent.com/71292860/184675627-e4bd40b6-690d-4b5d-953e-8e0b94748629.png)

To Test:
- [x] Click button to make sure link works
- [x] If no previous rounds, style should match above
- [x] Create a past round on [dynasty](https://dfdao-dynasty.netlify.app/) and make sure it appears in the history page