### PR TITLE
DF-104 build player data view

### DIFF
--- a/src/Frontend/Components/Badges.tsx
+++ b/src/Frontend/Components/Badges.tsx
@@ -1,0 +1,41 @@
+// should be able to be treated as a text element
+import { DarkForestBadge, BadgeType, getBadgeElement } from '@darkforest_eth/ui';
+import { createComponent } from '@lit-labs/react';
+import React from 'react';
+
+// TODO: Decide if this is the best place to register the custom elements
+customElements.define(DarkForestBadge.tagName, DarkForestBadge);
+
+// This wraps the customElement in a React wrapper to make it behave exactly like a React component
+export const Badge = createComponent(React, DarkForestBadge.tagName, DarkForestBadge, {
+  // If we had any, we would map DOM events to React handlers passed in as props. For example:
+  // onClick: 'click'
+});
+
+// Re-export the IconType abstract type & the "enum" object for easier access
+export { BadgeType } from '@darkforest_eth/ui';
+
+export function BadgeDetails({ type }: { type: BadgeType }) {
+  const badgeElement = getBadgeElement(type);
+  if (!badgeElement) return <></>;
+
+  return (
+    <div>
+      <Badge type={type} />
+      {badgeElement.name}
+      {badgeElement.description}
+    </div>
+  );
+}
+
+export function SpacedBadges({ badges }: { badges: BadgeType[] }) {
+  return (
+    <div>
+      {badges.map((badge, idx) => (
+        <Badge key={`badge-idx-${idx}`} type={badge} />
+      ))}
+    </div>
+  );
+}
+
+export function StackedBadges({}: {}) {}

--- a/src/Frontend/Components/Badges.tsx
+++ b/src/Frontend/Components/Badges.tsx
@@ -2,6 +2,7 @@
 import { DarkForestBadge, BadgeType, getBadgeElement } from '@darkforest_eth/ui';
 import { createComponent } from '@lit-labs/react';
 import React from 'react';
+import styled from 'styled-components';
 
 // TODO: Decide if this is the best place to register the custom elements
 customElements.define(DarkForestBadge.tagName, DarkForestBadge);

--- a/src/Frontend/Components/Badges.tsx
+++ b/src/Frontend/Components/Badges.tsx
@@ -20,11 +20,11 @@ export function BadgeDetails({ type }: { type: BadgeType }) {
   if (!badgeElement) return <></>;
 
   return (
-    <div>
+    <BadgeDetailsContainer>
       <Badge type={type} />
-      {badgeElement.name}
-      {badgeElement.description}
-    </div>
+      <span style={{ fontSize: '1.25rem' }}>{badgeElement.name}</span>
+      <span>{badgeElement.description}</span>
+    </BadgeDetailsContainer>
   );
 }
 
@@ -39,3 +39,11 @@ export function SpacedBadges({ badges }: { badges: BadgeType[] }) {
 }
 
 export function StackedBadges({}: {}) {}
+
+const BadgeDetailsContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  justify-content: center;
+`;

--- a/src/Frontend/Views/Portal/Account.tsx
+++ b/src/Frontend/Views/Portal/Account.tsx
@@ -86,7 +86,7 @@ function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
   );
 }
 export function Account() {
-  const [open, setOpen] = useState<boolean>(true);
+  const [open, setOpen] = useState<boolean>(false);
   const connection = useEthConnection();
   const address = connection.getAddress();
   const twitters = useTwitters();

--- a/src/Frontend/Views/Portal/Account.tsx
+++ b/src/Frontend/Views/Portal/Account.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { logOut } from '../../../Backend/Network/AccountManager';
 import { Gnosis, Icon, IconType, Twitter } from '../../Components/Icons';
@@ -8,7 +8,17 @@ import dfstyles from '../../Styles/dfstyles';
 import { useEthConnection, useTwitters } from '../../Utils/AppHooks';
 import { truncateAddress } from './PortalUtils';
 
+function AccountModal({}: {}) {
+  return (
+    <ModalContainer>
+      <AccountDetails>
+        <span>hello mama</span>
+      </AccountDetails>
+    </ModalContainer>
+  );
+}
 export function Account() {
+  const [open, setOpen] = useState<boolean>(true);
   const connection = useEthConnection();
   const address = connection.getAddress();
   const twitters = useTwitters();
@@ -17,34 +27,39 @@ export function Account() {
   const truncatedAddress = truncateAddress(address);
 
   return (
-    <PaneContainer>
-      <IconContainer>
-        {' '}
-        <button onClick={logOut}>Logout</button>
-      </IconContainer>
-      <a
-        style={{ display: 'flex', alignItems: 'center' }}
-        target='_blank'
-        href={`https://blockscout.com/xdai/optimism/address/${address}`}
-      >
-        <GnoButton>
-          <Gnosis width='24px' height='24px' />
-        </GnoButton>
-      </a>
-      {twitter && (
-        <a
-          style={{ display: 'flex', alignItems: 'center' }}
-          target='_blank'
-          href={`https://twitter.com/${twitter}`}
-        >
-          <Twitter width='24px' height='24px' />
-        </a>
-      )}
-
-      <NamesContainer>{twitter || truncatedAddress}</NamesContainer>
-    </PaneContainer>
+    <>
+      {open && <AccountModal />}
+      <PaneContainer>
+        <NamesContainer onClick={() => setOpen(true)}>{twitter || truncatedAddress}</NamesContainer>
+      </PaneContainer>
+    </>
   );
 }
+
+const ModalContainer = styled.div`
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const AccountDetails = styled.div`
+  min-width: 50%;
+  background: #38383b;
+  border: 1px solid #676767;
+  color: #dddde9;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 12px;
+  border-radius: 5px;
+`;
 
 const PaneContainer = styled.div`
   padding: 8px;
@@ -65,7 +80,7 @@ const IconContainer = styled.div`
   border-radius: 2px;
 `;
 
-const NamesContainer = styled.div`
+const NamesContainer = styled.button`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/Frontend/Views/Portal/Account.tsx
+++ b/src/Frontend/Views/Portal/Account.tsx
@@ -9,6 +9,12 @@ import { useEthConnection, useTwitters } from '../../Utils/AppHooks';
 import { truncateAddress } from './PortalUtils';
 
 function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
+  const connection = useEthConnection();
+  const address = connection.getAddress();
+  const twitters = useTwitters();
+  if (!address) return <></>;
+  const twitter = twitters[address];
+  const truncatedAddress = truncateAddress(address);
   return (
     <ModalContainer>
       <AccountDetails>
@@ -18,7 +24,32 @@ function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
         >
           <Icon type={IconType.X} />
         </button>
-        <span>hello mama</span>
+        <div style={{ fontSize: '2em' }}>{twitter || truncatedAddress}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <IconContainer
+            onClick={() => {
+              window.open(`https://blockscout.com/xdai/optimism/address/${address}`, '_blank');
+            }}
+          >
+            <GnoButton>
+              <Gnosis width='24px' height='24px' />
+            </GnoButton>
+            Account Details
+          </IconContainer>
+          {twitter && (
+            <IconContainer
+              onClick={() => {
+                window.open(`https://twitter.com/${twitter}`, '_blank');
+              }}
+            >
+              <Twitter width='24px' height='24px' />
+              {twitter ? 'Twitter' : 'Connect'}
+            </IconContainer>
+          )}
+        </div>
+        {/*badges*/}
+        <div></div>
+        <IconContainer onClick={logOut}>Logout</IconContainer>
       </AccountDetails>
     </ModalContainer>
   );
@@ -51,6 +82,7 @@ const ModalContainer = styled.div`
   background: rgba(0, 0, 0, 0.6);
   z-index: 1000;
   display: flex;
+  text-align: center;
   justify-content: center;
   align-items: center;
 `;
@@ -63,9 +95,11 @@ const AccountDetails = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
   padding: 12px;
   border-radius: 5px;
   position: relative;
+  gap: 8px;
 `;
 
 const PaneContainer = styled.button`
@@ -79,12 +113,13 @@ const PaneContainer = styled.button`
   justify-self: flex-end;
 `;
 
-const IconContainer = styled.div`
+const IconContainer = styled.button`
   padding: 2px;
   display: flex;
   gap: 4px;
   background: rgba(255, 255, 255, 0.03);
-  border-radius: 2px;
+  border-radius: 5px;
+  padding: 4px;
 `;
 
 const NamesContainer = styled.div`

--- a/src/Frontend/Views/Portal/Account.tsx
+++ b/src/Frontend/Views/Portal/Account.tsx
@@ -1,12 +1,16 @@
+import { BadgeType } from '@darkforest_eth/ui';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { logOut } from '../../../Backend/Network/AccountManager';
+import { Badge, BadgeDetails, SpacedBadges } from '../../Components/Badges';
 import { Gnosis, Icon, IconType, Twitter } from '../../Components/Icons';
 import { WithdrawSilverButton } from '../../Panes/Game/TooltipPanes';
 
 import dfstyles from '../../Styles/dfstyles';
 import { useEthConnection, useTwitters } from '../../Utils/AppHooks';
 import { truncateAddress } from './PortalUtils';
+
+const mockBadges: BadgeType[] = [BadgeType.Dfdao, BadgeType.Dfdao];
 
 function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
   const connection = useEthConnection();
@@ -47,8 +51,13 @@ function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
             </IconContainer>
           )}
         </div>
-        {/*badges*/}
-        <div></div>
+        <div>
+          Badges
+          <SpacedBadges badges={mockBadges} />
+          {mockBadges.map((badge, idx) => (
+            <BadgeDetails type={badge} />
+          ))}
+        </div>
         <IconContainer onClick={logOut}>Logout</IconContainer>
       </AccountDetails>
     </ModalContainer>

--- a/src/Frontend/Views/Portal/Account.tsx
+++ b/src/Frontend/Views/Portal/Account.tsx
@@ -37,8 +37,12 @@ function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
     [mockBadges]
   );
   return (
-    <ModalContainer>
-      <AccountDetails>
+    <ModalContainer onClick={() => setOpen(false)}>
+      <AccountDetails
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
         <AccountContent>
           <button
             style={{ position: 'absolute', top: '12px', right: '12px' }}
@@ -67,9 +71,8 @@ function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
               </Btn>
             )}
           </div>
-          <div style={{ display: 'flex', width: '100%' }}>
-            <TiledTable items={badgeElements} paginated={true} title='Your Badges' />
-          </div>
+          {/* <StackedBadges items={mockBadges} /> */}
+          <TiledTable items={badgeElements} paginated={true} title='Your Badges' />
         </AccountContent>
         <Footer>
           <Btn onClick={logOut}>Logout</Btn>
@@ -117,7 +120,7 @@ const AccountContent = styled.div`
 `;
 
 const AccountDetails = styled.div`
-  min-width: clamp(40%, 50%, 60%);
+  width: 600px;
   height: 60%;
   background: #38383b;
   border: 1px solid #676767;

--- a/src/Frontend/Views/Portal/Account.tsx
+++ b/src/Frontend/Views/Portal/Account.tsx
@@ -1,16 +1,28 @@
 import { BadgeType } from '@darkforest_eth/ui';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { logOut } from '../../../Backend/Network/AccountManager';
 import { Badge, BadgeDetails, SpacedBadges } from '../../Components/Badges';
+import { Btn } from '../../Components/Btn';
 import { Gnosis, Icon, IconType, Twitter } from '../../Components/Icons';
 import { WithdrawSilverButton } from '../../Panes/Game/TooltipPanes';
 
 import dfstyles from '../../Styles/dfstyles';
 import { useEthConnection, useTwitters } from '../../Utils/AppHooks';
+import { TiledTable } from '../TiledTable';
 import { truncateAddress } from './PortalUtils';
 
-const mockBadges: BadgeType[] = [BadgeType.Dfdao, BadgeType.Dfdao];
+const mockBadges: BadgeType[] = [
+  BadgeType.Dfdao,
+  BadgeType.Dfdao,
+  BadgeType.Dfdao,
+  BadgeType.Dfdao,
+  BadgeType.Dfdao,
+  BadgeType.Dfdao,
+  BadgeType.Dfdao,
+  BadgeType.Dfdao,
+  BadgeType.Dfdao,
+];
 
 function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
   const connection = useEthConnection();
@@ -19,46 +31,49 @@ function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
   if (!address) return <></>;
   const twitter = twitters[address];
   const truncatedAddress = truncateAddress(address);
+
+  const badgeElements = useMemo(
+    () => mockBadges.map((badge, idx) => <BadgeDetails type={badge} key={`badge-${idx}`} />),
+    [mockBadges]
+  );
   return (
     <ModalContainer>
       <AccountDetails>
-        <button
-          style={{ position: 'absolute', top: '12px', right: '12px' }}
-          onClick={() => setOpen(false)}
-        >
-          <Icon type={IconType.X} />
-        </button>
-        <div style={{ fontSize: '2em' }}>{twitter || truncatedAddress}</div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <IconContainer
-            onClick={() => {
-              window.open(`https://blockscout.com/xdai/optimism/address/${address}`, '_blank');
-            }}
+        <AccountContent>
+          <button
+            style={{ position: 'absolute', top: '12px', right: '12px' }}
+            onClick={() => setOpen(false)}
           >
-            <GnoButton>
-              <Gnosis width='24px' height='24px' />
-            </GnoButton>
-            Account Details
-          </IconContainer>
-          {twitter && (
-            <IconContainer
+            <Icon type={IconType.X} />
+          </button>
+          <div style={{ fontSize: '2em' }}>{twitter || truncatedAddress}</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <Btn
               onClick={() => {
-                window.open(`https://twitter.com/${twitter}`, '_blank');
+                window.open(`https://blockscout.com/xdai/optimism/address/${address}`, '_blank');
               }}
             >
-              <Twitter width='24px' height='24px' />
-              {twitter ? 'Twitter' : 'Connect'}
-            </IconContainer>
-          )}
-        </div>
-        <div>
-          Badges
-          <SpacedBadges badges={mockBadges} />
-          {mockBadges.map((badge, idx) => (
-            <BadgeDetails type={badge} />
-          ))}
-        </div>
-        <IconContainer onClick={logOut}>Logout</IconContainer>
+              <Gnosis width='24px' height='24px' />
+              Account Details
+            </Btn>
+            {twitter && (
+              <Btn
+                onClick={() => {
+                  window.open(`https://twitter.com/${twitter}`, '_blank');
+                }}
+              >
+                <Twitter width='24px' height='24px' />
+                {twitter ? 'Twitter' : 'Connect'}
+              </Btn>
+            )}
+          </div>
+          <div style={{ display: 'flex', width: '100%' }}>
+            <TiledTable items={badgeElements} paginated={true} title='Your Badges' />
+          </div>
+        </AccountContent>
+        <Footer>
+          <Btn onClick={logOut}>Logout</Btn>
+        </Footer>
       </AccountDetails>
     </ModalContainer>
   );
@@ -75,9 +90,7 @@ export function Account() {
   return (
     <>
       {open && <AccountModal setOpen={setOpen} />}
-      <PaneContainer onClick={() => setOpen(true)}>
-        <NamesContainer>{twitter || truncatedAddress}</NamesContainer>
-      </PaneContainer>
+      <PaneContainer onClick={() => setOpen(true)}>{twitter || truncatedAddress}</PaneContainer>
     </>
   );
 }
@@ -96,19 +109,25 @@ const ModalContainer = styled.div`
   align-items: center;
 `;
 
+const AccountContent = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+`;
+
 const AccountDetails = styled.div`
-  min-width: 50%;
+  min-width: clamp(40%, 50%, 60%);
+  height: 60%;
   background: #38383b;
   border: 1px solid #676767;
   color: #dddde9;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
   padding: 12px;
+  justify-content: space-between;
   border-radius: 5px;
   position: relative;
-  gap: 8px;
 `;
 
 const PaneContainer = styled.button`
@@ -122,22 +141,9 @@ const PaneContainer = styled.button`
   justify-self: flex-end;
 `;
 
-const IconContainer = styled.button`
-  padding: 2px;
+const Footer = styled.div`
+  width: 100%;
+  border-top: solid 1px #676767;
   display: flex;
-  gap: 4px;
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 5px;
-  padding: 4px;
-`;
-
-const NamesContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-`;
-const GnoButton = styled.button`
-  // background-color: ${dfstyles.colors.text};
-  border-radius: 30%;
-  border-color: ${dfstyles.colors.border};
+  padding-top: 12px;
 `;

--- a/src/Frontend/Views/Portal/Account.tsx
+++ b/src/Frontend/Views/Portal/Account.tsx
@@ -8,10 +8,16 @@ import dfstyles from '../../Styles/dfstyles';
 import { useEthConnection, useTwitters } from '../../Utils/AppHooks';
 import { truncateAddress } from './PortalUtils';
 
-function AccountModal({}: {}) {
+function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
   return (
     <ModalContainer>
       <AccountDetails>
+        <button
+          style={{ position: 'absolute', top: '12px', right: '12px' }}
+          onClick={() => setOpen(false)}
+        >
+          <Icon type={IconType.X} />
+        </button>
         <span>hello mama</span>
       </AccountDetails>
     </ModalContainer>
@@ -28,9 +34,9 @@ export function Account() {
 
   return (
     <>
-      {open && <AccountModal />}
-      <PaneContainer>
-        <NamesContainer onClick={() => setOpen(true)}>{twitter || truncatedAddress}</NamesContainer>
+      {open && <AccountModal setOpen={setOpen} />}
+      <PaneContainer onClick={() => setOpen(true)}>
+        <NamesContainer>{twitter || truncatedAddress}</NamesContainer>
       </PaneContainer>
     </>
   );
@@ -59,9 +65,10 @@ const AccountDetails = styled.div`
   justify-content: center;
   padding: 12px;
   border-radius: 5px;
+  position: relative;
 `;
 
-const PaneContainer = styled.div`
+const PaneContainer = styled.button`
   padding: 8px;
   position: relative;
   display: flex;
@@ -80,7 +87,7 @@ const IconContainer = styled.div`
   border-radius: 2px;
 `;
 
-const NamesContainer = styled.button`
+const NamesContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/Frontend/Views/Portal/Account.tsx
+++ b/src/Frontend/Views/Portal/Account.tsx
@@ -72,7 +72,11 @@ function AccountModal({ setOpen }: { setOpen: (open: boolean) => void }) {
             )}
           </div>
           {/* <StackedBadges items={mockBadges} /> */}
-          <TiledTable items={badgeElements} paginated={true} title='Your Badges' />
+          {badgeElements && badgeElements.length > 0 ? (
+            <TiledTable items={badgeElements} paginated={true} title='Your Badges' />
+          ) : (
+            'You have no badges'
+          )}
         </AccountContent>
         <Footer>
           <Btn onClick={logOut}>Logout</Btn>

--- a/src/Frontend/Views/TiledTable.tsx
+++ b/src/Frontend/Views/TiledTable.tsx
@@ -1,0 +1,99 @@
+import _ from 'lodash';
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { Btn } from '../Components/Btn';
+import { Spacer } from '../Components/CoreUI';
+import { Row } from '../Components/Row';
+
+const TableContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const ScrollableBody = styled.div`
+  width: 100%;
+  overflow-y: scroll;
+`;
+
+const PaginationContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+`;
+
+/**
+ * React api for creating tables.
+ * @param rows - rows of an arbitrary type
+ * @param headers - required (for now) array of strings that head each column
+ * @param columns - functions, one per column, that convert a row into the react representation of
+ * that row's column's value.
+ * @param alignments - optional, one per column, specifies that the text-alignment in that cell is
+ * either right, center, or left, represented by the characters 'r', 'c', and 'l'
+ */
+export function TiledTable({
+  items,
+  paginated,
+  rowsPerPage = 2,
+  columnsPerPage = 3,
+  title,
+}: {
+  items: React.ReactNode[];
+  headerStyle?: React.CSSProperties;
+  paginated?: boolean;
+  rowsPerPage?: number;
+  columnsPerPage?: number;
+  title?: string;
+}) {
+  const [page, setPage] = useState(0);
+
+  const itemsPerPage = rowsPerPage * columnsPerPage;
+  const visibleItems = useMemo(
+    () =>
+      createTable(
+        paginated ? items.slice(page * itemsPerPage, page * itemsPerPage + itemsPerPage) : items
+      ),
+    [page]
+  );
+
+  function createTable(items: React.ReactNode[]) {
+    return _.chunk(items, columnsPerPage).map((row, colIdx) => {
+      return (
+        <Row key={`tiledTable-row-${colIdx}`}>
+          {row.map((item, itemIdx) => (
+            <React.Fragment key={`tiled-Table-item-${colIdx}-${itemIdx}`}>{item}</React.Fragment>
+          ))}
+        </Row>
+      );
+    });
+  }
+
+  return (
+    <TableContainer>
+      <Row>
+        <span>{title}</span>
+        {paginated && items.length > itemsPerPage && (
+          <>
+            <Spacer height={16} />
+            <PaginationContainer>
+              <div>
+                <Btn onClick={() => setPage(Math.max(page - 1, 0))}>&lt;</Btn>
+                <Spacer width={8} />
+                Page: {page + 1} of {Math.floor(items.length / itemsPerPage) + 1}
+                <Spacer width={8} />
+                <Btn
+                  onClick={() =>
+                    setPage(Math.min(page + 1, Math.floor(items.length / itemsPerPage)))
+                  }
+                >
+                  &gt;
+                </Btn>
+              </div>
+            </PaginationContainer>
+          </>
+        )}
+      </Row>
+      <ScrollableBody>{visibleItems}</ScrollableBody>
+    </TableContainer>
+  );
+}


### PR DESCRIPTION
Branch Requirements: packages: branch `0xhank/dfd-116-badge-component-in-client`
Overview: a profile details pane that shows etherscan, twitter, badges, and log out
![image](https://user-images.githubusercontent.com/71292860/185698083-598a9a8d-23d2-43de-a6a5-8114370c1dbf.png)

To test:
- [x] Modal opens when you click the address in the top right
- [x] Modal closes when you press X button
- [x] Modal closes when you click outside the modal content
- [x] etherscan button takes you to etherscan
- [x] Twitter button appears when your twitter is connected and takes you to your twitter page
- [x] Delete/add a badge in the `mockbadges` array in `Account.tsx` and see the update occur in the modal
- [x] logout button logs you out of the portal