### PR TITLE
DFD-163 rewrite entry page

### DIFF
--- a/src/Frontend/Pages/EntryPage.tsx
+++ b/src/Frontend/Pages/EntryPage.tsx
@@ -144,7 +144,7 @@ class EntryPageTerminal {
 
     if (+userInput && +userInput <= accounts.length && +userInput > 0) {
       const selectedAccount = accounts[+userInput - 1];
-      this.drip(selectedAccount);
+      this.drip(selectedAccount, false);
     } else if (userInput === 'n') {
       this.generateAccount();
     } else if (userInput === 'i') {
@@ -249,7 +249,7 @@ class EntryPageTerminal {
     } catch (e) {}
   }
 
-  private async drip(account: Account) {
+  private async drip(account: Account, tutorialStep: boolean = true) {
     try {
       const currBalance = weiToEth(await this.ethConnection.loadBalance(account.address));
       if (currBalance < 0.005) {
@@ -262,7 +262,8 @@ class EntryPageTerminal {
           throw new Error('drip failed.');
         }
       }
-      this.playTutorial(account);
+      if (tutorialStep) await this.playTutorial(account);
+      else await this.setAccount(account, false);
     } catch (e) {
       console.log(e);
       this.terminal?.println('Registation failed. Try again with an account that has XDAI tokens.');

--- a/src/Frontend/Pages/EntryPage.tsx
+++ b/src/Frontend/Pages/EntryPage.tsx
@@ -106,7 +106,10 @@ class EntryPageTerminal {
 
     const accounts = getAccounts();
 
-    this.terminal?.println(`Found ${accounts.length} accounts on this device. Loading balances...`);
+    this.terminal?.println(`Login or create an account.`);
+    this.terminal?.println(`To choose an option, type its symbol and press ENTER.`);
+    this.terminal?.newline();
+    this.terminal?.println(`Found ${accounts.length} accounts on this device. `);
     this.terminal?.newline();
 
     try {
@@ -120,10 +123,6 @@ class EntryPageTerminal {
       return;
     }
 
-    this.terminal?.println(`Log in to create an arena. If your account has less than 0.005 xDAI`);
-    this.terminal?.println(`it will get dripped 0.01 Optimism xDAI`);
-    this.terminal?.newline();
-
     accounts.forEach((account, i) => {
       this.terminal?.print(`(${i + 1}): `, TerminalTextStyle.Sub);
       this.terminal?.print(`${account.address} `);
@@ -135,9 +134,9 @@ class EntryPageTerminal {
     this.terminal?.newline();
 
     this.terminal?.print('(n) ', TerminalTextStyle.Sub);
-    this.terminal?.println(`Generate new burner wallet account.`);
+    this.terminal?.println(`Create new account.`);
     this.terminal?.print('(i) ', TerminalTextStyle.Sub);
-    this.terminal?.println(`Import private key.`);
+    this.terminal?.println(`Import account using private key.`);
     this.terminal?.println(``);
     this.terminal?.println(`Select an option:`, TerminalTextStyle.Text);
 
@@ -168,24 +167,15 @@ class EntryPageTerminal {
       addAccount(account.privateKey);
 
       this.terminal.println(``);
-      this.terminal.print(`Created new burner wallet with address `);
+      this.terminal.print(`Creating new account with address `);
       this.terminal.printElement(<TextPreview text={account.address} unFocusedWidth={'100px'} />);
       this.terminal.println(``);
       this.terminal.println('');
-      this.terminal.println(
-        'Note: Burner wallets are stored in local storage.',
-        TerminalTextStyle.Text
-      );
-      this.terminal.println('They are relatively insecure and you should avoid ');
-      this.terminal.println('storing substantial funds in them.');
-      this.terminal.println('');
-      this.terminal.println('Also, clearing browser local storage/cache will render your');
-      this.terminal.println('burner wallets inaccessible, unless you export your private keys.');
-      this.terminal.println('');
-
+      this.terminal.print('Note: This account is a ', TerminalTextStyle.Sub);
+      this.terminal.println('burner wallet.', TerminalTextStyle.Red);
+      this.terminal.println('It should never store substantial funds!', TerminalTextStyle.Sub);
+      this.terminal.newline();
       this.setAccount(account);
-
-      // this.accountSet(newAddr);
     } catch (e) {
       console.log(e);
       this.terminal.println('An unknown error occurred. please try again.', TerminalTextStyle.Red);
@@ -194,16 +184,14 @@ class EntryPageTerminal {
 
   private async importAccount() {
     this.terminal.println(
-      'Enter the 0x-prefixed private key of the account you wish to import',
+      'Enter the 0x-prefixed private key of the account you wish to import.',
       TerminalTextStyle.Text
     );
-    this.terminal.println(
-      "NOTE: THIS WILL STORE THE PRIVATE KEY IN YOUR BROWSER'S LOCAL STORAGE",
-      TerminalTextStyle.Text
-    );
-    this.terminal.println(
-      'Local storage is relatively insecure. We recommend only importing accounts with zero-to-no funds.'
-    );
+    this.terminal.newline();
+    this.terminal.print('Note: This account is a ', TerminalTextStyle.Sub);
+    this.terminal.println('burner wallet.', TerminalTextStyle.Red);
+    this.terminal.println('It should never store substantial funds!', TerminalTextStyle.Sub);
+
     this.terminal.newline();
     this.terminal.println('(x) to cancel', TerminalTextStyle.Text);
     this.terminal.newline();
@@ -287,13 +275,13 @@ export function EntryPage() {
     if (connection) {
       console.log(`loading registry...`);
       loadRegistry(connection)
-      .then((t) => {
-        setSeasonData(t)
-      })
-      .catch((e) => {
-        console.log(`load registry error`, e);
-        setSeasonData([])
-      })
+        .then((t) => {
+          setSeasonData(t);
+        })
+        .catch((e) => {
+          console.log(`load registry error`, e);
+          setSeasonData([]);
+        });
     }
   }, [connection]);
 

--- a/src/Frontend/Pages/EntryPage.tsx
+++ b/src/Frontend/Pages/EntryPage.tsx
@@ -164,8 +164,6 @@ class EntryPageTerminal {
     };
 
     try {
-      addAccount(account.privateKey);
-
       this.terminal.println(``);
       this.terminal.print(`Creating new account with address `);
       this.terminal.printElement(<TextPreview text={account.address} unFocusedWidth={'100px'} />);
@@ -175,7 +173,7 @@ class EntryPageTerminal {
       this.terminal.println('burner wallet.', TerminalTextStyle.Red);
       this.terminal.println('It should never store substantial funds!', TerminalTextStyle.Sub);
       this.terminal.newline();
-      this.playTutorial(account);
+      this.drip(account);
     } catch (e) {
       console.log(e);
       this.terminal.println('An unknown error occurred. please try again.', TerminalTextStyle.Red);
@@ -205,12 +203,10 @@ class EntryPageTerminal {
     try {
       const newAddr = address(utils.computeAddress(newSKey));
 
-      addAccount(newSKey);
-
       this.terminal.println(`Successfully created account with address ${newAddr.toString()}`);
       this.terminal.newline();
 
-      this.playTutorial({ address: newAddr, privateKey: newSKey });
+      this.drip({ address: newAddr, privateKey: newSKey });
     } catch (e) {
       this.terminal.println('An unknown error occurred. please try again.', TerminalTextStyle.Red);
       this.terminal.println('');
@@ -232,7 +228,9 @@ class EntryPageTerminal {
 
   private async playTutorial(account: Account) {
     try {
-      await this.drip(account);
+      if (!getAccounts().find((acc) => acc.address == account.address))
+        addAccount(account.privateKey);
+
       this.terminal.println('This is a new account. Would you like to play the tutorial?');
       this.terminal?.print('(y) ', TerminalTextStyle.Sub);
       this.terminal?.println(`Yes. Take me to the tutorial.`);

--- a/src/Frontend/Pages/EntryPage.tsx
+++ b/src/Frontend/Pages/EntryPage.tsx
@@ -195,7 +195,7 @@ class EntryPageTerminal {
     this.terminal.newline();
     this.terminal.println('(x) to cancel', TerminalTextStyle.Text);
     this.terminal.newline();
-    const newSKey = (await this.terminal.getInput()) || '';
+    const newSKey = await this.terminal.getInput();
     if (newSKey === 'x') {
       this.terminal.newline();
       this.terminal.println('Cancelled import.', TerminalTextStyle.Text);

--- a/src/Frontend/Pages/Game/GameLandingPage.tsx
+++ b/src/Frontend/Pages/Game/GameLandingPage.tsx
@@ -85,6 +85,7 @@ export function GameLandingPage({ match, location }: RouteComponentProps<{ contr
   const useZkWhitelist = params.has('zkWhitelist');
   const selectedAddress = params.get('account');
   const createInstance = params.has('create');
+  const [fromCreate, setFromCreate] = useState(false);
   const isLobby = contractAddress !== address(CONTRACT_ADDRESS);
   const CHUNK_SIZE = 5;
   const defaultAddress = address(CONTRACT_ADDRESS);
@@ -109,6 +110,7 @@ export function GameLandingPage({ match, location }: RouteComponentProps<{ contr
           const { owner, lobby } = await newCreationManager.createAndInitArena(fetchedConfig);
 
           if (owner == playerAddress) {
+            setFromCreate(true);  
             history.push({ pathname: `${lobby}`, state: { contract: lobby } });
             setContractAddress(lobby);
           }
@@ -175,7 +177,7 @@ export function GameLandingPage({ match, location }: RouteComponentProps<{ contr
         console.log('loaded config hash', configHash);
         setConfigHash(configHash);
 
-        if (configHash === tutorialConfig) {
+        if (configHash === tutorialConfig || fromCreate) {
           setStep(TerminalPromptStep.PLAYING);
           return;
         }
@@ -183,14 +185,18 @@ export function GameLandingPage({ match, location }: RouteComponentProps<{ contr
 
       terminal.current?.println(``);
       terminal.current?.println(
+        fromCreate ?
+        `Would you like to play with this account?`:
         `Would you like to play or spectate this game?`,
         TerminalTextStyle.Sub
       );
 
       terminal.current?.print('(a) ', TerminalTextStyle.Sub);
       terminal.current?.println(`Play.`);
-      terminal.current?.print('(s) ', TerminalTextStyle.Sub);
-      terminal.current?.println(`Spectate.`);
+      if(!fromCreate) {
+        terminal.current?.print('(s) ', TerminalTextStyle.Sub);
+        terminal.current?.println(`Spectate.`);
+      }
       terminal.current?.print(`(d) `, TerminalTextStyle.Sub);
       terminal.current?.println(`Change account.`);
 

--- a/src/Frontend/Utils/constants.ts
+++ b/src/Frontend/Utils/constants.ts
@@ -24,7 +24,7 @@ const LOCATION_ID_UB = bigInt(
 
 const competitiveConfig = '0xfe719a3cfccf2bcfa23f71f0af80a931eda4f4197331828d728b7505a6156930';
 
-const tutorialConfig = '0xdccc97271cde9ad566db3a1e1d3d12220b04b595134bb7039b5606fdc57d82a1';
+const tutorialConfig = '0x2d37631ddc22529de8144f0dbe640b10ea159a2a9e6837686b9fd06a91857ec1';
 
 const roundStartTimestamp = '2022-07-13T00:00:00.000Z';
 


### PR DESCRIPTION
Description: Updates the entry page onboarding flow to remove jargon and be simpler for a non crypto-native player to interact. Also adds a new PLAY TUTORIAL step if account is imported/generated, which asks the user if they want to play.
![image](https://user-images.githubusercontent.com/71292860/188645835-eb76e882-e42e-482e-a554-d76d3eead65a.png)
![image](https://user-images.githubusercontent.com/71292860/188645899-ada6aed3-0150-40ee-89c3-87531b884e54.png)
![image](https://user-images.githubusercontent.com/71292860/188645958-b9599650-2dc8-46d6-95ca-6ee380a9bd7a.png)
![image](https://user-images.githubusercontent.com/71292860/188645986-1ac17f43-c840-4867-966f-460366d3f304.png)

To test:
- [ ] enter the portal with an account that is preloaded AND has xdai. It should take you straight to the portal.
- [ ] enter with an account that is preloaded AND has no xdai. It should drip and take you straight to the portal.
- [ ] generate an account. it should drip and continue to tutorial step.
- [ ] import an account that has xdai. it shouldn't drip and it should continue to tutorial step.
- [ ] import an account without xdai. it should drip and it should continue to tutorial step.
- [ ] Choosing yes on the tutorial step redirects to the tutorial config map
- [ ] Choosing no on the tutorial step takes you to the portal