### PR TITLE
DFD-149 in game clarify target planet location

### DIFF
--- a/src/Frontend/Panes/Game/ArenaBriefingPane.tsx
+++ b/src/Frontend/Panes/Game/ArenaBriefingPane.tsx
@@ -13,12 +13,12 @@ const enum BriefingStep {
 }
 export function ArenaBriefingPane() {
   const uiManager = useUIManager();
-  const [open, setOpen] = useState(uiManager.gameStarted);
+  const [open, setOpen] = useState(!uiManager.gameStarted);
   const [step, setStep] = useState<BriefingStep>(BriefingStep.Welcome);
 
   const config = {
-    contractAddress: this.uiManager.getContractAddress(),
-    account: this.uiManager.getAccount(),
+    contractAddress: uiManager.getContractAddress(),
+    account: uiManager.getAccount(),
   };
   const spectatorMode = uiManager.getGameManager().getIsSpectator();
   const isSinglePlayer = uiManager.getSpawnPlanets().length == 1;

--- a/src/Frontend/Panes/Game/ArenaBriefingPane.tsx
+++ b/src/Frontend/Panes/Game/ArenaBriefingPane.tsx
@@ -63,7 +63,9 @@ export function ArenaBriefingPane() {
             .
           </>
         )}
-        <div>You need {numForVictory} target planets to claim victory.</div>
+        <div>
+          You need {numForVictory} target planet{numForVictory > 1 && 's'} to claim victory.
+        </div>
       </div>
       <br />
       <div style={{ gap: '5px' }}>
@@ -85,7 +87,8 @@ export function ArenaBriefingPane() {
       </div>
       <br />
       <div>
-        ⏲️ starts {isSinglePlayer ? 'with your first move' : 'when you press ready'}. Good luck!
+        The timer ⏲️ starts {isSinglePlayer ? 'with your first move' : 'when you press ready'}. Good
+        luck!
       </div>
       <br />
       <div style={{ gap: '5px' }}>

--- a/src/Frontend/Panes/Game/ArenaBriefingPane.tsx
+++ b/src/Frontend/Panes/Game/ArenaBriefingPane.tsx
@@ -1,77 +1,115 @@
-import React, {  useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Btn } from '../../Components/Btn';
-import { Bronze, Gold, Green, Silver } from '../../Components/Text';
-import { bronzeTime, goldTime, silverTime } from '../../Utils/constants';
+import { Gold, Green } from '../../Components/Text';
 import { useUIManager } from '../../Utils/AppHooks';
-import { formatDuration } from '../../Utils/TimeUtils';
 import { StyledTutorialPane } from './StyledTutorialPane';
+import { setBooleanSetting } from '../../Utils/SettingsHooks';
+import { Setting } from '@darkforest_eth/types';
 
-
+const enum BriefingStep {
+  Welcome,
+  Target,
+  Complete,
+}
 export function ArenaBriefingPane() {
-  const [open, setOpen] = useState(true);
   const uiManager = useUIManager();
+  const [open, setOpen] = useState(uiManager.gameStarted);
+  const [step, setStep] = useState<BriefingStep>(BriefingStep.Welcome);
+
+  const config = {
+    contractAddress: this.uiManager.getContractAddress(),
+    account: this.uiManager.getAccount(),
+  };
   const spectatorMode = uiManager.getGameManager().getIsSpectator();
-  const isSinglePlayer = uiManager.getSpawnPlanets().length == 1 
+  const isSinglePlayer = uiManager.getSpawnPlanets().length == 1;
   const victoryThreshold = uiManager.contractConstants.CLAIM_VICTORY_ENERGY_PERCENT;
   const numForVictory = uiManager.contractConstants.TARGETS_REQUIRED_FOR_VICTORY;
-  const isCompetitive = uiManager.isCompetitive();
-
+  const targetLocation = uiManager.getPlayerTargetPlanets()[0].locationId;
+  const targetCoords = uiManager.getGameManager().getRevealedLocations().get(targetLocation);
+  const homeLocation = uiManager.getHomeHash();
+  useEffect(() => {
+    if (step == BriefingStep.Target) {
+      uiManager.centerLocationId(targetLocation);
+    } else if (step == BriefingStep.Complete) {
+      if (homeLocation) uiManager.centerLocationId(homeLocation);
+    }
+  }, [step]);
 
   if (spectatorMode || !open) {
     return null;
   }
 
+  const welcomeContent = (
+    <div className='tutzoom'>
+      Welcome to Dark Forest Arena!
+      <br />
+      <br />
+      <div>
+        {isSinglePlayer ? (
+          <>
+            Race against the clock to capture the Target Planet (it has a big 🎯 floating above it)
+            and{' '}
+            <Green>
+              claim victory when it contains at least <Gold>{victoryThreshold}%</Gold> energy!
+            </Green>
+          </>
+        ) : (
+          <>
+            Battle your opponent to capture the Target Planet (it has a big 🎯 floating above it)
+            and{' '}
+            <Green>
+              claim victory when it contains at least <Gold>{victoryThreshold}%</Gold> energy!
+            </Green>
+            .
+          </>
+        )}
+        <div>You need {numForVictory} target planets to claim victory.</div>
+      </div>
+      <br />
+      <div style={{ gap: '5px' }}>
+        <Btn className='btn' onClick={() => setOpen(false)}>
+          Close
+        </Btn>
+        <Btn className='btn' onClick={() => setStep(BriefingStep.Target)}>
+          View Target Planet
+        </Btn>
+      </div>
+    </div>
+  );
+
+  const targetContent = (
+    <div className='tutZoom'>
+      <div>
+        This is your objective: the 🎯 Target Planet.{' '}
+        {targetCoords && `It is located at (${targetCoords.coords.x}, ${targetCoords.coords.y}).`}
+      </div>
+      <br />
+      <div>
+        ⏲️ starts {isSinglePlayer ? 'with your first move' : 'when you press ready'}. Good luck!
+      </div>
+      <br />
+      <div style={{ gap: '5px' }}>
+        <Btn
+          className='btn'
+          onClick={() => {
+            setOpen(false);
+            setStep(BriefingStep.Complete);
+            setBooleanSetting(config, Setting.ShowArenaBriefing, true);
+          }}
+        >
+          Return to home planet
+        </Btn>
+      </div>
+    </div>
+  );
+
+  const completeContent = <></>;
+
   return (
     <StyledTutorialPane>
-      <div className='tutzoom'>
-        Welcome to Dark Forest Arena!
-        <br />
-        <br />
-        <div>
-          {isSinglePlayer? (
-            <>
-              Race against the clock to capture the Target Planet (it has a big 🎯 floating above
-              it) and{' '}
-              <Green>
-                claim victory when it contains at least <Gold>{victoryThreshold}%</Gold> energy!
-              </Green>
-            </>
-          ) : (
-            <>
-              Battle your opponent to capture the Target Planet (it has a big 🎯 floating above it)
-              and{' '}
-              <Green>
-                claim victory when it contains at least <Gold>{victoryThreshold}%</Gold> energy!
-              </Green>
-              .
-            </>
-          )}
-          You need {numForVictory} to win.
-        </div>
-        {isCompetitive && isSinglePlayer && (
-          <div>
-            <p>End the race in a certain time to earn Bronze, Silver, and Gold ranks.</p>
-            <p>
-              Gold: <Gold>{formatDuration(goldTime * 1000)}</Gold>
-            </p>
-            <p>
-              Silver: <Silver>{formatDuration(silverTime * 1000)}</Silver>
-            </p>
-            <p>
-              Bronze: <Bronze>{formatDuration(bronzeTime * 1000)}</Bronze>
-            </p>
-          </div>
-        )}
-        <div>
-          ⏲️ starts {isSinglePlayer ? 'with your first move' : 'when you press ready'}!
-          {isCompetitive && isSinglePlayer && 'The player with the fastest time after 48hrs will win XDAI and a 🏆!'}
-        </div>
-        <div style={{ gap: '5px' }}>
-          <Btn className='btn' onClick={() => setOpen(false)}>
-            Next
-          </Btn>
-        </div>
-      </div>
+      {step == BriefingStep.Welcome && welcomeContent}
+      {step == BriefingStep.Target && targetContent}
+      {step == BriefingStep.Complete && completeContent}
     </StyledTutorialPane>
   );
 }

--- a/src/Frontend/Panes/Game/ArenaBriefingPane.tsx
+++ b/src/Frontend/Panes/Game/ArenaBriefingPane.tsx
@@ -24,16 +24,24 @@ export function ArenaBriefingPane() {
   const isSinglePlayer = uiManager.getSpawnPlanets().length == 1;
   const victoryThreshold = uiManager.contractConstants.CLAIM_VICTORY_ENERGY_PERCENT;
   const numForVictory = uiManager.contractConstants.TARGETS_REQUIRED_FOR_VICTORY;
-  const targetLocation = uiManager.getPlayerTargetPlanets()[0].locationId;
-  const targetCoords = uiManager.getGameManager().getRevealedLocations().get(targetLocation);
+  const targetLocations = uiManager.getPlayerTargetPlanets();
+  const targetLocation = targetLocations.length > 0 ? targetLocations[0] : undefined;
+  const targetCoords = targetLocation
+    ? uiManager.getGameManager().getRevealedLocations().get(targetLocation.locationId)
+    : undefined;
   const homeLocation = uiManager.getHomeHash();
   useEffect(() => {
-    if (step == BriefingStep.Target) {
-      uiManager.centerLocationId(targetLocation);
+    if (!targetLocation) setStep(BriefingStep.Complete);
+    if (step == BriefingStep.Target && targetLocation) {
+      uiManager.centerLocationId(targetLocation.locationId);
+    } else if (step === BriefingStep.Target && !targetLocation) {
+      setStep(BriefingStep.Complete);
     } else if (step == BriefingStep.Complete) {
       if (homeLocation) uiManager.centerLocationId(homeLocation);
+      setOpen(false);
+      setBooleanSetting(config, Setting.ShowArenaBriefing, true);
     }
-  }, [step]);
+  }, [step, setStep]);
 
   if (spectatorMode || !open) {
     return null;
@@ -95,9 +103,7 @@ export function ArenaBriefingPane() {
         <Btn
           className='btn'
           onClick={() => {
-            setOpen(false);
             setStep(BriefingStep.Complete);
-            setBooleanSetting(config, Setting.ShowArenaBriefing, true);
           }}
         >
           Return to home planet

--- a/src/Frontend/Panes/Game/StyledTutorialPane.tsx
+++ b/src/Frontend/Panes/Game/StyledTutorialPane.tsx
@@ -9,6 +9,7 @@ export const StyledTutorialPane = styled.div`
   background: ${dfstyles.colors.backgroundlighter};
   color: ${dfstyles.colors.text};
   padding: 8px;
+  padding-top: 16px;
   border-bottom: 1px solid ${dfstyles.colors.border};
   border-right: 1px solid ${dfstyles.colors.border};
 


### PR DESCRIPTION
Description: Added an extra step in the briefing pane that show the player where the target planet is.
![image](https://user-images.githubusercontent.com/71292860/188682638-b8b5c2b4-f64e-48da-9a6a-4e9287297270.png)
![image](https://user-images.githubusercontent.com/71292860/188682843-023938c6-634b-49f9-94b0-3a4eb8beaa92.png)

To test:
- [ ] Make sure the target planet is viewed correctly on different maps
- [ ] Make sure the briefing pane doesn't appear if the game has already begun
- [ ] Check that the information displayed in the briefing pane is correct