### PR TITLE
fix: target blank for tabs

### DIFF
--- a/src/Frontend/Views/Portal/Components/MapGridDetail.tsx
+++ b/src/Frontend/Views/Portal/Components/MapGridDetail.tsx
@@ -71,7 +71,7 @@ export const MapGridDetail: React.FC<{
           )}
           <Link
             style={{ minWidth: '250px' }}
-            target='blank'
+            target='_blank'
             to={`/play/${lobbyAddress}?create=true`}
           ></Link>
         </>

--- a/src/Frontend/Views/Portal/Components/PortalHistoryRoundCard.tsx
+++ b/src/Frontend/Views/Portal/Components/PortalHistoryRoundCard.tsx
@@ -86,10 +86,10 @@ export const PortalHistoryRoundCard: React.FC<{ round: GrandPrixHistory; index: 
           <DetailLabel>Badges</DetailLabel>
           <DetailValue>{round.badges.length}</DetailValue>
         </DetailRow>
-        <Link style={{ minWidth: '250px' }} target='blank' to={`/play/${lobbyAddress}?create=true`}>
+        <Link style={{ minWidth: '250px' }} target='_blank' to={`/play/${lobbyAddress}?create=true`}>
           <LobbyButton primary>Play</LobbyButton>
         </Link>
-        <Link style={{ minWidth: '250px' }} target='blank' to={`/portal/map/${round.configHash}`}>
+        <Link style={{ minWidth: '250px' }} to={`/portal/map/${round.configHash}`}>
           <LobbyButton>Details</LobbyButton>
         </Link>
       </MapDetailsContainer>

--- a/src/Frontend/Views/Portal/MapInfoView.tsx
+++ b/src/Frontend/Views/Portal/MapInfoView.tsx
@@ -80,11 +80,8 @@ function MapOverview({
         />
       )}
       <div style={{ display: 'flex', gap: '16px', justifyContent: 'center', width: '100%' }}>
-        {/* <Link style={{ minWidth: '250px' }} target='blank' to={`/arena/${lobbyAddress}/settings`}>
-          <LobbyButton>Remix Map</LobbyButton>
-        </Link> */}
-        <Link style={{ minWidth: '250px' }} target='blank' to={`/play/${lobbyAddress}?create=true`}>
-          <LobbyButton primary>Create Match</LobbyButton>
+        <Link style={{ minWidth: '250px' }} target='_blank' to={`/play/${lobbyAddress}?create=true`}>
+          <LobbyButton primary>Play</LobbyButton>
         </Link>
       </div>
     </OverviewContainer>

--- a/src/Frontend/Views/Portal/MapOverview.tsx
+++ b/src/Frontend/Views/Portal/MapOverview.tsx
@@ -116,7 +116,7 @@ export const MapOverview: React.FC<{
           </div>
           <Title>{mapName ?? 'Grand Prix Round'}</Title>
           <MapActions>
-            <Link target='blank' to={`/play/${lobbyAddress}?create=true`}>
+            <Link target='_blank' to={`/play/${lobbyAddress}?create=true`}>
               <LobbyButton primary>
                 Play round
               </LobbyButton>


### PR DESCRIPTION
To test:
- [ ] Click on every `Play` button in the client and verify that they all open in new tabs
- [ ] Click on `Learn More` and verify that this opens in a new tab.
- [ ] Click around and make sure any non-Play links stay within portal, like `Details` and the map hyperlinks.